### PR TITLE
Add project management endpoints

### DIFF
--- a/src/main/java/com/example/clipbot_backend/controller/ProjectController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/ProjectController.java
@@ -1,0 +1,80 @@
+package com.example.clipbot_backend.controller;
+
+import com.example.clipbot_backend.dto.web.ProjectCreateRequest;
+import com.example.clipbot_backend.dto.web.ProjectMediaLinkRequest;
+import com.example.clipbot_backend.dto.web.ProjectMediaLinkResponse;
+import com.example.clipbot_backend.dto.web.ProjectResponse;
+import com.example.clipbot_backend.model.Clip;
+import com.example.clipbot_backend.model.Project;
+import com.example.clipbot_backend.model.ProjectMediaLink;
+import com.example.clipbot_backend.service.ProjectService;
+import com.example.clipbot_backend.util.ClipStatus;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/projects")
+public class ProjectController {
+    private final ProjectService projectService;
+
+    public ProjectController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @PostMapping
+    public ProjectResponse createProject(@Valid @RequestBody ProjectCreateRequest request) {
+        Project project = projectService.createProject(request.ownerId(), request.title(), request.templateId());
+        return toResponse(project);
+    }
+
+    @GetMapping
+    public Page<ProjectResponse> listProjects(@RequestParam UUID ownerId,
+                                              @RequestParam(defaultValue = "0") int page,
+                                              @RequestParam(defaultValue = "10") int size) {
+        return projectService.listProjects(ownerId, PageRequest.of(page, size)).map(this::toResponse);
+    }
+
+    @GetMapping("/{projectId}")
+    public ProjectResponse getProject(@PathVariable UUID projectId, @RequestParam UUID ownerId) {
+        Project project = projectService.getProject(projectId, ownerId);
+        return toResponse(project);
+    }
+
+    @PostMapping("/{projectId}/media")
+    public ProjectMediaLinkResponse linkMedia(@PathVariable UUID projectId,
+                                              @Valid @RequestBody ProjectMediaLinkRequest request) {
+        ProjectMediaLink link = projectService.linkMedia(projectId, request.ownerId(), request.mediaId());
+        return toResponse(link);
+    }
+
+    @GetMapping("/{projectId}/media")
+    public List<ProjectMediaLinkResponse> listMedia(@PathVariable UUID projectId, @RequestParam UUID ownerId) {
+        return projectService.listProjectMedia(projectId, ownerId)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @GetMapping("/{projectId}/clips")
+    public Page<Clip> listClips(@PathVariable UUID projectId,
+                                @RequestParam UUID ownerId,
+                                @RequestParam(required = false) ClipStatus status,
+                                @RequestParam(defaultValue = "0") int page,
+                                @RequestParam(defaultValue = "10") int size) {
+        return projectService.listProjectClips(projectId, ownerId, status, PageRequest.of(page, size));
+    }
+
+    private ProjectResponse toResponse(Project project) {
+        return new ProjectResponse(project.getId(), project.getOwner().getId(), project.getTitle(),
+                project.getCreatedAt(), project.getTemplateId());
+    }
+
+    private ProjectMediaLinkResponse toResponse(ProjectMediaLink link) {
+        return new ProjectMediaLinkResponse(link.getId().getProjectId(), link.getId().getMediaId(), link.getCreatedAt());
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/controller/ProjectController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/ProjectController.java
@@ -1,5 +1,6 @@
 package com.example.clipbot_backend.controller;
 
+import com.example.clipbot_backend.dto.web.ClipResponse;
 import com.example.clipbot_backend.dto.web.ProjectCreateRequest;
 import com.example.clipbot_backend.dto.web.ProjectMediaLinkRequest;
 import com.example.clipbot_backend.dto.web.ProjectMediaLinkResponse;
@@ -12,6 +13,8 @@ import com.example.clipbot_backend.util.ClipStatus;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,9 +30,9 @@ public class ProjectController {
     }
 
     @PostMapping
-    public ProjectResponse createProject(@Valid @RequestBody ProjectCreateRequest request) {
+    public ResponseEntity<ProjectResponse> createProject(@Valid @RequestBody ProjectCreateRequest request) {
         Project project = projectService.createProject(request.ownerId(), request.title(), request.templateId());
-        return toResponse(project);
+        return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(project));
     }
 
     @GetMapping
@@ -46,10 +49,10 @@ public class ProjectController {
     }
 
     @PostMapping("/{projectId}/media")
-    public ProjectMediaLinkResponse linkMedia(@PathVariable UUID projectId,
-                                              @Valid @RequestBody ProjectMediaLinkRequest request) {
+    public ResponseEntity<ProjectMediaLinkResponse> linkMedia(@PathVariable UUID projectId,
+                                                              @Valid @RequestBody ProjectMediaLinkRequest request) {
         ProjectMediaLink link = projectService.linkMedia(projectId, request.ownerId(), request.mediaId());
-        return toResponse(link);
+        return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(link));
     }
 
     @GetMapping("/{projectId}/media")
@@ -61,12 +64,13 @@ public class ProjectController {
     }
 
     @GetMapping("/{projectId}/clips")
-    public Page<Clip> listClips(@PathVariable UUID projectId,
-                                @RequestParam UUID ownerId,
-                                @RequestParam(required = false) ClipStatus status,
-                                @RequestParam(defaultValue = "0") int page,
-                                @RequestParam(defaultValue = "10") int size) {
-        return projectService.listProjectClips(projectId, ownerId, status, PageRequest.of(page, size));
+    public Page<ClipResponse> listClips(@PathVariable UUID projectId,
+                                        @RequestParam UUID ownerId,
+                                        @RequestParam(required = false) ClipStatus status,
+                                        @RequestParam(defaultValue = "0") int page,
+                                        @RequestParam(defaultValue = "10") int size) {
+        return projectService.listProjectClips(projectId, ownerId, status, PageRequest.of(page, size))
+                .map(this::toResponse);
     }
 
     private ProjectResponse toResponse(Project project) {
@@ -76,5 +80,24 @@ public class ProjectController {
 
     private ProjectMediaLinkResponse toResponse(ProjectMediaLink link) {
         return new ProjectMediaLinkResponse(link.getId().getProjectId(), link.getId().getMediaId(), link.getCreatedAt());
+    }
+
+    private ClipResponse toResponse(Clip clip) {
+        var segment = clip.getSourceSegment();
+        UUID segmentId = segment != null ? segment.getId() : null;
+        return new ClipResponse(
+                clip.getId(),
+                clip.getMedia().getId(),
+                segmentId,
+                clip.getStartMs(),
+                clip.getEndMs(),
+                clip.getStatus() != null ? clip.getStatus().name() : null,
+                clip.getTitle(),
+                clip.getCaptionSrtKey(),
+                clip.getCaptionVttKey(),
+                clip.getMeta(),
+                clip.getCreatedAt(),
+                clip.getVersion()
+        );
     }
 }

--- a/src/main/java/com/example/clipbot_backend/dto/web/ClipResponse.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/ClipResponse.java
@@ -1,0 +1,21 @@
+package com.example.clipbot_backend.dto.web;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+public record ClipResponse(
+        UUID id,
+        UUID mediaId,
+        UUID sourceSegmentId,
+        long startMs,
+        long endMs,
+        String status,
+        String title,
+        String captionSrtKey,
+        String captionVttKey,
+        Map<String, Object> meta,
+        Instant createdAt,
+        long version
+) {
+}

--- a/src/main/java/com/example/clipbot_backend/dto/web/ProjectCreateRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/ProjectCreateRequest.java
@@ -1,0 +1,13 @@
+package com.example.clipbot_backend.dto.web;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record ProjectCreateRequest(
+        @NotNull UUID ownerId,
+        @NotBlank String title,
+        String templateId
+) {
+}

--- a/src/main/java/com/example/clipbot_backend/dto/web/ProjectMediaLinkRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/ProjectMediaLinkRequest.java
@@ -1,0 +1,11 @@
+package com.example.clipbot_backend.dto.web;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record ProjectMediaLinkRequest(
+        @NotNull UUID ownerId,
+        @NotNull UUID mediaId
+) {
+}

--- a/src/main/java/com/example/clipbot_backend/dto/web/ProjectMediaLinkResponse.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/ProjectMediaLinkResponse.java
@@ -1,0 +1,11 @@
+package com.example.clipbot_backend.dto.web;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ProjectMediaLinkResponse(
+        UUID projectId,
+        UUID mediaId,
+        Instant createdAt
+) {
+}

--- a/src/main/java/com/example/clipbot_backend/dto/web/ProjectResponse.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/ProjectResponse.java
@@ -1,0 +1,13 @@
+package com.example.clipbot_backend.dto.web;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ProjectResponse(
+        UUID id,
+        UUID ownerId,
+        String title,
+        Instant createdAt,
+        String templateId
+) {
+}

--- a/src/main/java/com/example/clipbot_backend/model/Project.java
+++ b/src/main/java/com/example/clipbot_backend/model/Project.java
@@ -1,0 +1,74 @@
+package com.example.clipbot_backend.model;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "project")
+public class Project {
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "owner_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_project_owner"))
+    private Account owner;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "template_id", length = 255)
+    private String templateId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    protected Project() {
+    }
+
+    public Project(Account owner, String title, String templateId) {
+        this.owner = owner;
+        this.title = title;
+        this.templateId = templateId;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Account getOwner() {
+        return owner;
+    }
+
+    public void setOwner(Account owner) {
+        this.owner = owner;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getTemplateId() {
+        return templateId;
+    }
+
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/model/ProjectMediaId.java
+++ b/src/main/java/com/example/clipbot_backend/model/ProjectMediaId.java
@@ -1,0 +1,46 @@
+package com.example.clipbot_backend.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+@Embeddable
+public class ProjectMediaId implements Serializable {
+    @Column(name = "project_id", nullable = false)
+    private UUID projectId;
+
+    @Column(name = "media_id", nullable = false)
+    private UUID mediaId;
+
+    public ProjectMediaId() {
+    }
+
+    public ProjectMediaId(UUID projectId, UUID mediaId) {
+        this.projectId = projectId;
+        this.mediaId = mediaId;
+    }
+
+    public UUID getProjectId() {
+        return projectId;
+    }
+
+    public UUID getMediaId() {
+        return mediaId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProjectMediaId that = (ProjectMediaId) o;
+        return Objects.equals(projectId, that.projectId) && Objects.equals(mediaId, that.mediaId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(projectId, mediaId);
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/model/ProjectMediaLink.java
+++ b/src/main/java/com/example/clipbot_backend/model/ProjectMediaLink.java
@@ -1,0 +1,54 @@
+package com.example.clipbot_backend.model;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "project_media")
+public class ProjectMediaLink {
+    @EmbeddedId
+    private ProjectMediaId id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId("projectId")
+    @JoinColumn(name = "project_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_project_media_project"))
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId("mediaId")
+    @JoinColumn(name = "media_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_project_media_media"))
+    private Media media;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    protected ProjectMediaLink() {
+    }
+
+    public ProjectMediaLink(Project project, Media media) {
+        this.project = project;
+        this.media = media;
+        this.id = new ProjectMediaId(project.getId(), media.getId());
+    }
+
+    public ProjectMediaId getId() {
+        return id;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public Media getMedia() {
+        return media;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/repository/ClipRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/ClipRepository.java
@@ -7,9 +7,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.UUID;
 
 public interface ClipRepository extends JpaRepository<Clip, UUID> {
     Page<Clip> findByMediaOrderByCreatedAtDesc(Media media, Pageable pageable);
     Page<Clip> findByMediaAndStatusOrderByCreatedAtDesc(Media media, ClipStatus status, Pageable pageable);
+    Page<Clip> findByMediaInOrderByCreatedAtDesc(Collection<Media> media, Pageable pageable);
+    Page<Clip> findByMediaInAndStatusOrderByCreatedAtDesc(Collection<Media> media, ClipStatus status, Pageable pageable);
 }

--- a/src/main/java/com/example/clipbot_backend/repository/ProjectMediaRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/ProjectMediaRepository.java
@@ -1,0 +1,19 @@
+package com.example.clipbot_backend.repository;
+
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.model.Project;
+import com.example.clipbot_backend.model.ProjectMediaId;
+import com.example.clipbot_backend.model.ProjectMediaLink;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ProjectMediaRepository extends JpaRepository<ProjectMediaLink, ProjectMediaId> {
+    boolean existsByProjectAndMedia(Project project, Media media);
+    List<ProjectMediaLink> findByProject(Project project);
+
+    @Query("select pm.media from ProjectMediaLink pm where pm.project = :project")
+    List<Media> findMediaByProject(@Param("project") Project project);
+}

--- a/src/main/java/com/example/clipbot_backend/repository/ProjectRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/ProjectRepository.java
@@ -1,0 +1,13 @@
+package com.example.clipbot_backend.repository;
+
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Project;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ProjectRepository extends JpaRepository<Project, UUID> {
+    Page<Project> findByOwnerOrderByCreatedAtDesc(Account owner, Pageable pageable);
+}

--- a/src/main/java/com/example/clipbot_backend/service/ProjectService.java
+++ b/src/main/java/com/example/clipbot_backend/service/ProjectService.java
@@ -1,0 +1,102 @@
+package com.example.clipbot_backend.service;
+
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Clip;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.model.Project;
+import com.example.clipbot_backend.model.ProjectMediaLink;
+import com.example.clipbot_backend.repository.AccountRepository;
+import com.example.clipbot_backend.repository.ClipRepository;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.repository.ProjectMediaRepository;
+import com.example.clipbot_backend.repository.ProjectRepository;
+import com.example.clipbot_backend.util.ClipStatus;
+import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ProjectService {
+    private final ProjectRepository projectRepository;
+    private final ProjectMediaRepository projectMediaRepository;
+    private final AccountRepository accountRepository;
+    private final MediaRepository mediaRepository;
+    private final ClipRepository clipRepository;
+
+    public ProjectService(ProjectRepository projectRepository,
+                          ProjectMediaRepository projectMediaRepository,
+                          AccountRepository accountRepository,
+                          MediaRepository mediaRepository,
+                          ClipRepository clipRepository) {
+        this.projectRepository = projectRepository;
+        this.projectMediaRepository = projectMediaRepository;
+        this.accountRepository = accountRepository;
+        this.mediaRepository = mediaRepository;
+        this.clipRepository = clipRepository;
+    }
+
+    @Transactional
+    public Project createProject(UUID ownerId, String title, String templateId) {
+        Account owner = accountRepository.findById(ownerId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "OWNER_NOT_FOUND"));
+        var project = new Project(owner, title, templateId);
+        return projectRepository.save(project);
+    }
+
+    public Page<Project> listProjects(UUID ownerId, Pageable pageable) {
+        Account owner = accountRepository.findById(ownerId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "OWNER_NOT_FOUND"));
+        return projectRepository.findByOwnerOrderByCreatedAtDesc(owner, pageable);
+    }
+
+    public Project getProject(UUID projectId, UUID ownerId) {
+        return ensureProjectOwnedBy(projectId, ownerId);
+    }
+
+    @Transactional
+    public ProjectMediaLink linkMedia(UUID projectId, UUID ownerId, UUID mediaId) {
+        Project project = ensureProjectOwnedBy(projectId, ownerId);
+        Media media = mediaRepository.findById(mediaId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "MEDIA_NOT_FOUND"));
+        if (!media.getOwner().getId().equals(ownerId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "FORBIDDEN");
+        }
+        if (projectMediaRepository.existsByProjectAndMedia(project, media)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "MEDIA_ALREADY_LINKED");
+        }
+        var link = new ProjectMediaLink(project, media);
+        return projectMediaRepository.save(link);
+    }
+
+    public List<ProjectMediaLink> listProjectMedia(UUID projectId, UUID ownerId) {
+        Project project = ensureProjectOwnedBy(projectId, ownerId);
+        return projectMediaRepository.findByProject(project);
+    }
+
+    public Page<Clip> listProjectClips(UUID projectId, UUID ownerId, ClipStatus status, Pageable pageable) {
+        Project project = ensureProjectOwnedBy(projectId, ownerId);
+        List<Media> mediaList = projectMediaRepository.findMediaByProject(project);
+        if (mediaList.isEmpty()) {
+            return Page.empty(pageable);
+        }
+        if (status != null) {
+            return clipRepository.findByMediaInAndStatusOrderByCreatedAtDesc(mediaList, status, pageable);
+        }
+        return clipRepository.findByMediaInOrderByCreatedAtDesc(mediaList, pageable);
+    }
+
+    private Project ensureProjectOwnedBy(UUID projectId, UUID ownerId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "PROJECT_NOT_FOUND"));
+        if (!project.getOwner().getId().equals(ownerId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "FORBIDDEN");
+        }
+        return project;
+    }
+}

--- a/src/main/resources/db/migration/V4__projects.sql
+++ b/src/main/resources/db/migration/V4__projects.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS project (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    owner_id UUID NOT NULL REFERENCES account(id) ON DELETE CASCADE,
+    title VARCHAR(255) NOT NULL,
+    template_id VARCHAR(255),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_owner_created ON project(owner_id, created_at);
+
+CREATE TABLE IF NOT EXISTS project_media (
+    project_id UUID NOT NULL REFERENCES project(id) ON DELETE CASCADE,
+    media_id UUID NOT NULL REFERENCES media(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (project_id, media_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_media_project ON project_media(project_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_project_media_media ON project_media(media_id);


### PR DESCRIPTION
## Summary
- add REST endpoints to create, list, and retrieve projects plus link media and list related clips
- add persistence models, repositories, and service logic for projects with owner permission checks
- add database migration and repository support for project-media linking and clip queries

## Testing
- ./mvnw test *(fails: unable to download Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ed6655f8cc833189a855d8b6b056d7