### PR TITLE
Narrow subtitle block and reduce default size

### DIFF
--- a/src/main/java/com/example/clipbot_backend/engine/FfmpegClipRenderEngine.java
+++ b/src/main/java/com/example/clipbot_backend/engine/FfmpegClipRenderEngine.java
@@ -26,6 +26,17 @@ import java.util.UUID;
 public class FfmpegClipRenderEngine  implements ClipRenderEngine {
     private static final Logger LOGGER = LoggerFactory.getLogger(FfmpegClipRenderEngine.class);
 
+    private static final int FONT_MIN_PX = 14;
+    private static final int FONT_MAX_PX = 36;
+    private static final int MIN_MARGIN_V_PX = 44;
+    private static final int MIN_MARGIN_H_PX = 120;
+    private static final double OUTLINE_RATIO = 0.08;
+    private static final double AR_THRESHOLD = 1.3;
+    private static final double DEFAULT_WIDE_FONT_MUL = 0.0200;
+    private static final double DEFAULT_TALL_FONT_MUL = 0.0230;
+    private static final double DEFAULT_WIDE_MARGIN_MUL = 0.18;
+    private static final double DEFAULT_TALL_MARGIN_MUL = 0.15;
+
     private final StorageService storageService;
     private final String ffmpegBin;
     private final Path workDir;
@@ -56,15 +67,18 @@ public class FfmpegClipRenderEngine  implements ClipRenderEngine {
     private String subtitleStyleForHeight(int videoH, int videoW,@Nullable Map<String,Object> meta) {
         // Dynamisch per aspect ratio
         double ar = (videoW > 0) ? (videoW * 1.0 / Math.max(1, videoH)) : 16.0/9.0;
-        double mul = (ar >= 1.3) ? 0.0222 : 0.0260;
+        double mul = (ar >= AR_THRESHOLD) ? DEFAULT_WIDE_FONT_MUL : DEFAULT_TALL_FONT_MUL;
         Double sc = asDbl(meta, "subtitleScale");
         if (sc != null) {
             // guardrails
             mul = Math.max(0.014, Math.min(0.030, sc));
         }
-        int fontPx   = Math.max(14, Math.min(36, (int)Math.round(videoH * mul))); // ~30px @1080p
-        int outline = Math.max(1, Math.min(2, (int)Math.round(fontPx * 0.08)));  // dunne rand
-        int marginV = Math.max(44, (int)Math.round(videoH * 0.006)); // ~32px @1080p
+        int fontPx   = Math.max(FONT_MIN_PX, Math.min(FONT_MAX_PX, (int)Math.round(videoH * mul))); // ~22px @1080p
+        int outline = Math.max(1, Math.min(2, (int)Math.round(fontPx * OUTLINE_RATIO)));  // dunne rand
+        int marginV = Math.max(MIN_MARGIN_V_PX, (int)Math.round(videoH * 0.006)); // ~32px @1080p
+
+        double marginHMul = ar >= AR_THRESHOLD ? DEFAULT_WIDE_MARGIN_MUL : DEFAULT_TALL_MARGIN_MUL; // bredere schermen → smallere textblock breedte
+        int marginH = Math.max(MIN_MARGIN_H_PX, (int)Math.round(videoW * marginHMul)); // grotere marge voor meer regelafbreking
 
         return "FontName=Inter Semi Bold"
                 + ",FontSize=" + fontPx
@@ -75,7 +89,7 @@ public class FfmpegClipRenderEngine  implements ClipRenderEngine {
                 + ",Outline=" + outline
                 + ",Shadow=0"
                 + ",Spacing=0"
-                + ",MarginL=44,MarginR=44,MarginV=" + marginV
+                + ",MarginL=" + marginH + ",MarginR=" + marginH + ",MarginV=" + marginV
                 + ",Alignment=2"
                 + ",WrapStyle=2"; // nette regelafbreking
     }


### PR DESCRIPTION
## Summary
- lower the default subtitle font scaling and centralize sizing constants
- increase minimum and proportional horizontal margins so long lines wrap sooner and stay centered

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c6aa69f7c8331aae29a795f057d72)