### PR TITLE
Add clip profile hash uniqueness and render stats

### DIFF
--- a/src/main/java/com/example/clipbot_backend/model/Clip.java
+++ b/src/main/java/com/example/clipbot_backend/model/Clip.java
@@ -6,11 +6,17 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
 @Entity
+@Table(name = "clip", uniqueConstraints = {
+        @UniqueConstraint(name = "ux_clip_media_range_profile",
+                columnNames = {"media_id", "start_ms", "end_ms", "profile_hash"})
+})
 public class Clip {
     @Id
     @GeneratedValue
@@ -47,6 +53,12 @@ public class Clip {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "meta")
     private Map<String, Object> meta;
+
+    @Column(name = "profile_hash", nullable = false, columnDefinition = "text")
+    private String profileHash = "";
+
+    @Column(name = "score", precision = 6, scale = 3)
+    private BigDecimal score;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -87,6 +99,31 @@ public class Clip {
     public Instant getCreatedAt() { return createdAt; }
     public long getVersion() { return version; }
 
+    /**
+     * Returns the render profile hash that differentiates clips with identical ranges.
+     *
+     * @return profile hash, never {@code null}.
+     */
+    public String getProfileHash() { return profileHash; }
 
+    /**
+     * Updates the profile hash used for deduplicating clip ranges.
+     *
+     * @param profileHash profile hash value, must not be {@code null}.
+     */
+    public void setProfileHash(String profileHash) { this.profileHash = profileHash; }
 
+    /**
+     * Returns the recommendation score assigned to the clip.
+     *
+     * @return score or {@code null} when no score is known.
+     */
+    public BigDecimal getScore() { return score; }
+
+    /**
+     * Stores the recommendation score for the clip.
+     *
+     * @param score score value or {@code null}.
+     */
+    public void setScore(BigDecimal score) { this.score = score; }
 }

--- a/src/main/java/com/example/clipbot_backend/model/RenderStats.java
+++ b/src/main/java/com/example/clipbot_backend/model/RenderStats.java
@@ -1,0 +1,107 @@
+package com.example.clipbot_backend.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.UUID;
+
+/**
+ * Aggregated render statistics used for estimating render durations per profile kind.
+ */
+@Entity
+@Table(name = "render_stats", uniqueConstraints = {
+        @UniqueConstraint(name = "ux_render_stats_kind", columnNames = {"kind"})
+})
+public class RenderStats {
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "kind", nullable = false, columnDefinition = "text")
+    private String kind;
+
+    @Column(name = "avg_ms", nullable = false)
+    private long avgMs;
+
+    @Column(name = "count", nullable = false)
+    private long count;
+
+    protected RenderStats() {
+    }
+
+    public RenderStats(String kind, long avgMs, long count) {
+        this.kind = kind;
+        this.avgMs = avgMs;
+        this.count = count;
+    }
+
+    /**
+     * Returns the primary key.
+     *
+     * @return unique identifier.
+     */
+    public UUID getId() {
+        return id;
+    }
+
+    /**
+     * Returns the render kind (e.g. profile or codec name).
+     *
+     * @return non-null kind string.
+     */
+    public String getKind() {
+        return kind;
+    }
+
+    /**
+     * Updates the render kind key.
+     *
+     * @param kind non-null kind string.
+     */
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    /**
+     * Returns the moving-average duration in milliseconds.
+     *
+     * @return average render duration.
+     */
+    public long getAvgMs() {
+        return avgMs;
+    }
+
+    /**
+     * Updates the moving-average duration in milliseconds.
+     *
+     * @param avgMs average render duration.
+     */
+    public void setAvgMs(long avgMs) {
+        this.avgMs = avgMs;
+    }
+
+    /**
+     * Returns the sample count that contributed to the moving average.
+     *
+     * @return number of samples.
+     */
+    public long getCount() {
+        return count;
+    }
+
+    /**
+     * Updates the sample count that contributed to the moving average.
+     *
+     * @param count number of samples.
+     */
+    public void setCount(long count) {
+        this.count = count;
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/repository/ClipRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/ClipRepository.java
@@ -23,6 +23,12 @@ public interface ClipRepository extends JpaRepository<Clip, UUID> {
     List<StatusCount> countByMediaInGroupByStatus(List<Media> media);
     interface StatusCount { ClipStatus getStatus(); long getCnt(); }
 
+    /**
+     * Loads a clip with its media and media owner eagerly fetched.
+     *
+     * @param id clip identifier.
+     * @return optional clip including media and owner relations.
+     */
     @Query("""
            select c
            from Clip c
@@ -31,5 +37,31 @@ public interface ClipRepository extends JpaRepository<Clip, UUID> {
            where c.id = :id
            """)
     Optional<Clip> findByIdWithMedia(@Param("id") UUID id);
+
+    /**
+     * Returns clips for the given media ordered by descending recommendation score.
+     *
+     * @param mediaId media identifier.
+     * @param pageable pagination information.
+     * @return clips sorted by score and creation time.
+     */
+    @Query("""
+            select c
+            from Clip c
+            where c.media.id = :mediaId
+            order by coalesce(c.score, 0) desc, c.createdAt desc
+            """)
+    List<Clip> findByMediaIdOrderByScoreDesc(@Param("mediaId") UUID mediaId, Pageable pageable);
+
+    /**
+     * Looks up a clip by media range and profile hash combination.
+     *
+     * @param mediaId media identifier.
+     * @param startMs start offset in milliseconds.
+     * @param endMs end offset in milliseconds.
+     * @param profileHash render profile hash.
+     * @return optional clip matching the unique combination.
+     */
+    Optional<Clip> findByMediaIdAndStartMsAndEndMsAndProfileHash(UUID mediaId, long startMs, long endMs, String profileHash);
 
 }

--- a/src/main/java/com/example/clipbot_backend/repository/RenderStatsRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/RenderStatsRepository.java
@@ -1,0 +1,20 @@
+package com.example.clipbot_backend.repository;
+
+import com.example.clipbot_backend.model.RenderStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository for tracking render statistics per profile kind.
+ */
+public interface RenderStatsRepository extends JpaRepository<RenderStats, UUID> {
+    /**
+     * Finds statistics for the given kind.
+     *
+     * @param kind render kind identifier.
+     * @return optional statistics entity.
+     */
+    Optional<RenderStats> findByKind(String kind);
+}

--- a/src/main/resources/db/migration/V21__clip_profile_hash_and_render_stats.sql
+++ b/src/main/resources/db/migration/V21__clip_profile_hash_and_render_stats.sql
@@ -1,0 +1,25 @@
+ALTER TABLE clip
+    ADD COLUMN IF NOT EXISTS profile_hash TEXT;
+
+UPDATE clip SET profile_hash = '' WHERE profile_hash IS NULL;
+
+ALTER TABLE clip
+    ALTER COLUMN profile_hash SET NOT NULL;
+
+ALTER TABLE clip
+    ALTER COLUMN profile_hash SET DEFAULT '';
+
+ALTER TABLE clip
+    ADD COLUMN IF NOT EXISTS score NUMERIC(6,3);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_clip_media_range_profile
+    ON clip(media_id, start_ms, end_ms, profile_hash);
+
+CREATE TABLE IF NOT EXISTS render_stats (
+    id UUID PRIMARY KEY,
+    kind TEXT NOT NULL,
+    avg_ms BIGINT NOT NULL DEFAULT 0,
+    count BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_render_stats_kind ON render_stats(kind);

--- a/src/test/java/com/example/clipbot_backend/repository/ClipRepositoryTest.java
+++ b/src/test/java/com/example/clipbot_backend/repository/ClipRepositoryTest.java
@@ -1,0 +1,46 @@
+package com.example.clipbot_backend.repository;
+
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Clip;
+import com.example.clipbot_backend.model.Media;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DataJpaTest
+class ClipRepositoryTest {
+
+    @Autowired
+    private ClipRepository clipRepository;
+
+    @Autowired
+    private MediaRepository mediaRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Test
+    void duplicateRangeWithProfileHashTriggersUniqueViolation() {
+        Account owner = accountRepository.save(new Account("ext-" + UUID.randomUUID(), "Owner"));
+        Media media = new Media(owner, "obj.mp4");
+        mediaRepository.saveAndFlush(media);
+
+        Clip first = new Clip(media, 1_000, 5_000);
+        first.setProfileHash("hash-A");
+        clipRepository.saveAndFlush(first);
+
+        Clip duplicate = new Clip(media, 1_000, 5_000);
+        duplicate.setProfileHash("hash-A");
+
+        DataIntegrityViolationException ex = assertThrows(DataIntegrityViolationException.class,
+                () -> clipRepository.saveAndFlush(duplicate));
+
+        assertThat(ex).isNotNull();
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/repository/RenderStatsRepositoryTest.java
+++ b/src/test/java/com/example/clipbot_backend/repository/RenderStatsRepositoryTest.java
@@ -1,0 +1,29 @@
+package com.example.clipbot_backend.repository;
+
+import com.example.clipbot_backend.model.RenderStats;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class RenderStatsRepositoryTest {
+
+    @Autowired
+    private RenderStatsRepository renderStatsRepository;
+
+    @Test
+    void saveAndFindByKindWorks() {
+        RenderStats stats = new RenderStats("CLIP_720P", 2_500L, 3L);
+        renderStatsRepository.saveAndFlush(stats);
+
+        assertThat(renderStatsRepository.findByKind("CLIP_720P"))
+                .isPresent()
+                .get()
+                .satisfies(found -> {
+                    assertThat(found.getAvgMs()).isEqualTo(2_500L);
+                    assertThat(found.getCount()).isEqualTo(3L);
+                });
+    }
+}


### PR DESCRIPTION
## Summary
- add a Flyway migration that introduces the render_stats table, enforces a unique clip range/profile hash combination and records clip scores
- extend the Clip model/repository with profile hash, score-aware lookups and the new RenderStats entity/repository for storing ETA data
- cover the repositories with focused JPA tests, including the profile-hash uniqueness violation scenario

## Testing
- `mvn -q -DskipITs test` *(fails: cannot resolve org.springframework.boot:spring-boot-starter-parent:3.5.6 from Maven Central – HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db7b6d09483318cadb89e02197a89)