### PR TITLE
Add recommendation pipeline and selector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.6.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
@@ -100,6 +99,12 @@
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.example</groupId>
+			<artifactId>clipbot-backend</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/example/clipbot_backend/api/dto/PageResponse.java
+++ b/src/main/java/com/example/clipbot_backend/api/dto/PageResponse.java
@@ -1,0 +1,10 @@
+package com.example.clipbot_backend.api.dto;
+
+import java.util.List;
+
+/**
+ * Stable pagination DTO to avoid exposing Spring Data internals in JSON.
+ */
+public record PageResponse<T>(List<T> content, int page, int size, long total) {
+}
+

--- a/src/main/java/com/example/clipbot_backend/controller/RecommendationController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/RecommendationController.java
@@ -1,0 +1,125 @@
+package com.example.clipbot_backend.controller;
+
+import com.example.clipbot_backend.dto.ClipSummary;
+import com.example.clipbot_backend.dto.RecommendationResult;
+import com.example.clipbot_backend.dto.web.ComputeRequest;
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.service.RecommendationService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * REST controller exposing recommendation endpoints.
+ */
+@RestController
+@RequestMapping("/v1/media/{mediaId}/recommendations")
+public class RecommendationController {
+
+    private final RecommendationService recommendationService;
+    private final MediaRepository mediaRepository;
+
+    public RecommendationController(RecommendationService recommendationService,
+                                    MediaRepository mediaRepository) {
+        this.recommendationService = recommendationService;
+        this.mediaRepository = mediaRepository;
+    }
+
+    /**
+     * Computes recommendations for the provided media and stores the resulting clips.
+     *
+     * @param mediaId media identifier.
+     * @param body    request payload with optional overrides.
+     * @param ownerExternalSubject ownership marker used for authorization.
+     * @return recommendation result with the selected clips.
+     */
+    @PostMapping("/compute")
+    public RecommendationResult compute(@PathVariable UUID mediaId,
+                                        @RequestBody(required = false) ComputeRequest body,
+                                        @RequestParam String ownerExternalSubject) {
+        Media media = ensureOwned(mediaId, ownerExternalSubject);
+        int topN = body != null && body.topN() != null ? body.topN() : 6;
+        Map<String, Object> profile = body != null && body.profile() != null ? body.profile() : Map.of();
+        boolean enqueue = body == null || body.enqueueRender() == null ? true : body.enqueueRender();
+        return recommendationService.computeRecommendations(media.getId(), topN, profile, enqueue);
+    }
+
+    /**
+     * Lists stored recommendations for the media sorted by score.
+     *
+     * @param mediaId media identifier.
+     * @param page    zero-based page index.
+     * @param size    page size.
+     * @param sort    sort expression formatted as "field,direction".
+     * @param ownerExternalSubject ownership marker used for authorization.
+     * @return pageable list of clip summaries.
+     */
+    @GetMapping
+    public Page<ClipSummary> list(@PathVariable UUID mediaId,
+                                  @RequestParam(defaultValue = "0") int page,
+                                  @RequestParam(defaultValue = "20") int size,
+                                  @RequestParam(defaultValue = "score,desc") String sort,
+                                  @RequestParam String ownerExternalSubject) {
+        ensureOwned(mediaId, ownerExternalSubject);
+        Pageable pageable = PageRequest.of(Math.max(0, page), Math.max(1, size), parseSort(sort));
+        return recommendationService.listRecommendations(mediaId, pageable);
+    }
+
+    /**
+     * Returns a human-readable explanation for the requested window.
+     *
+     * @param mediaId media identifier.
+     * @param startMs window start.
+     * @param endMs   window end.
+     * @param ownerExternalSubject ownership marker used for authorization.
+     * @return feature breakdown map.
+     */
+    @GetMapping("/explain")
+    public Map<String, String> explain(@PathVariable UUID mediaId,
+                                       @RequestParam long startMs,
+                                       @RequestParam long endMs,
+                                       @RequestParam String ownerExternalSubject) {
+        ensureOwned(mediaId, ownerExternalSubject);
+        if (startMs < 0 || endMs <= startMs) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_WINDOW");
+        }
+        return recommendationService.explain(mediaId, startMs, endMs);
+    }
+
+    private Media ensureOwned(UUID mediaId, String ownerExternalSubject) {
+        Media media = mediaRepository.findById(mediaId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "MEDIA_NOT_FOUND"));
+        Account owner = media.getOwner();
+        if (owner == null || !Objects.equals(owner.getExternalSubject(), ownerExternalSubject)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "MEDIA_NOT_OWNED");
+        }
+        return media;
+    }
+
+    private static Sort parseSort(String sort) {
+        if (sort == null || sort.isBlank()) {
+            return Sort.by(Sort.Order.desc("score"), Sort.Order.desc("createdAt"));
+        }
+        String[] parts = sort.split(",");
+        String property = parts[0].trim();
+        Sort.Direction direction = parts.length > 1 && "asc".equalsIgnoreCase(parts[1])
+                ? Sort.Direction.ASC : Sort.Direction.DESC;
+        return Sort.by(new Sort.Order(direction, property), Sort.Order.desc("createdAt"));
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/dto/ClipSummary.java
+++ b/src/main/java/com/example/clipbot_backend/dto/ClipSummary.java
@@ -1,0 +1,22 @@
+package com.example.clipbot_backend.dto;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Lightweight summary for recommended clips.
+ *
+ * @param id          clip identifier.
+ * @param startMs     start offset in milliseconds.
+ * @param endMs       end offset in milliseconds.
+ * @param score       recommendation score.
+ * @param status      current clip status string.
+ * @param profileHash hash for the applied render profile.
+ */
+public record ClipSummary(UUID id,
+                          long startMs,
+                          long endMs,
+                          BigDecimal score,
+                          String status,
+                          String profileHash) {
+}

--- a/src/main/java/com/example/clipbot_backend/dto/RecommendationResult.java
+++ b/src/main/java/com/example/clipbot_backend/dto/RecommendationResult.java
@@ -1,0 +1,14 @@
+package com.example.clipbot_backend.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Response payload for recommendation computations.
+ *
+ * @param mediaId media identifier.
+ * @param count   number of clips included in the result.
+ * @param clips   ordered clip summaries.
+ */
+public record RecommendationResult(UUID mediaId, int count, List<ClipSummary> clips) {
+}

--- a/src/main/java/com/example/clipbot_backend/dto/RenderSpec.java
+++ b/src/main/java/com/example/clipbot_backend/dto/RenderSpec.java
@@ -10,5 +10,5 @@ public record RenderSpec(@Min(144) @Max(7680) Integer width,
                          String preset,
                          String profile) {
     public static final RenderSpec DEFAULT =
-            new RenderSpec(1920, 1080, 30, 18, "medium", "high");
+            new RenderSpec(1280, 720, 30, 23, "fast", "youtube-720p");
 }

--- a/src/main/java/com/example/clipbot_backend/dto/web/ComputeRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/ComputeRequest.java
@@ -1,0 +1,15 @@
+package com.example.clipbot_backend.dto.web;
+
+import java.util.Map;
+
+/**
+ * Request payload for triggering recommendations.
+ *
+ * @param topN          optional override for the number of clips to store.
+ * @param profile       render/profile metadata supplied by the caller.
+ * @param enqueueRender whether to enqueue render jobs immediately.
+ */
+public record ComputeRequest(Integer topN,
+                              Map<String, Object> profile,
+                              Boolean enqueueRender) {
+}

--- a/src/main/java/com/example/clipbot_backend/engine/FfmpegClipRenderEngine.java
+++ b/src/main/java/com/example/clipbot_backend/engine/FfmpegClipRenderEngine.java
@@ -310,6 +310,7 @@ public class FfmpegClipRenderEngine  implements ClipRenderEngine {
         RenderSpec defaults = switch (spec.profile()) {
             case "tiktok-9x16" -> new RenderSpec(1080, 1920, 30, 23, "veryfast", "tiktok-9x16");
             case "youtube-1080p" -> new RenderSpec(1920, 1080, 30, 23, "fast", "youtube-1080p");
+            case "youtube-720p" -> new RenderSpec(1280, 720, 30, 23, "fast", "youtube-720p");
             default -> null;
         };
         if (defaults == null) return spec;

--- a/src/main/java/com/example/clipbot_backend/repository/ClipRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/ClipRepository.java
@@ -54,6 +54,17 @@ public interface ClipRepository extends JpaRepository<Clip, UUID> {
     List<Clip> findByMediaIdOrderByScoreDesc(@Param("mediaId") UUID mediaId, Pageable pageable);
 
     /**
+     * Returns a pageable list of clips for a given media id.
+     *
+     * @param mediaId media identifier.
+     * @param pageable pagination instructions (sorting is applied from pageable).
+     * @return page with clip entities.
+     */
+    @Query(value = "select c from Clip c where c.media.id = :mediaId",
+            countQuery = "select count(c) from Clip c where c.media.id = :mediaId")
+    Page<Clip> findPageByMediaId(@Param("mediaId") UUID mediaId, Pageable pageable);
+
+    /**
      * Looks up a clip by media range and profile hash combination.
      *
      * @param mediaId media identifier.

--- a/src/main/java/com/example/clipbot_backend/repository/MediaRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/MediaRepository.java
@@ -23,4 +23,11 @@ public interface MediaRepository extends JpaRepository<Media, UUID> {
        where m.id = :id
        """)
     Optional<Media> findByIdWithOwner(@Param("id") UUID id);
+
+    @Query("""
+           select m from Media m
+           join fetch m.owner o
+           where m.id = :id and o.externalSubject = :subj
+           """)
+    Optional<Media> findOwned(@Param("id") UUID id, @Param("subj") String subj);
 }

--- a/src/main/java/com/example/clipbot_backend/selector/GoodClipSelector.java
+++ b/src/main/java/com/example/clipbot_backend/selector/GoodClipSelector.java
@@ -1,0 +1,26 @@
+package com.example.clipbot_backend.selector;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Selects the best windows for a media item based on heuristic scoring.
+ */
+public interface GoodClipSelector {
+    /**
+     * Selects the top {@code N} windows sorted by score in descending order.
+     *
+     * @param windows windows for a single media item.
+     * @param topN    maximum number of results to return.
+     * @param cfg     selector configuration to apply.
+     * @return scored windows ordered by score.
+     */
+    List<ScoredWindow> selectTop(List<Window> windows, int topN, SelectorConfig cfg);
+
+    /**
+     * Returns the feature explanation for the last invocation of {@link #selectTop}.
+     *
+     * @return map keyed by "start-end" strings with feature breakdowns.
+     */
+    Map<String, String> explainLast();
+}

--- a/src/main/java/com/example/clipbot_backend/selector/HeuristicGoodClipSelector.java
+++ b/src/main/java/com/example/clipbot_backend/selector/HeuristicGoodClipSelector.java
@@ -1,0 +1,110 @@
+package com.example.clipbot_backend.selector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Default heuristic implementation that applies simple weights to window features.
+ */
+@Component
+public class HeuristicGoodClipSelector implements GoodClipSelector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HeuristicGoodClipSelector.class);
+    private volatile Map<String, String> lastExplanation = Map.of();
+
+    @Override
+    public List<ScoredWindow> selectTop(List<Window> windows, int topN, SelectorConfig cfg) {
+        SelectorConfig effective = cfg == null ? SelectorConfig.defaults() : cfg;
+        int limit = Math.max(1, topN);
+        List<ScoredWindow> scored = new ArrayList<>();
+        Map<String, String> explanations = new LinkedHashMap<>();
+
+        for (Window window : windows) {
+            if (window == null) {
+                continue;
+            }
+            if (window.speechDensity() < effective.minSpeechDensity()) {
+                LOGGER.trace("selector skip start={} end={} speechDensity={} below min", window.startMs(), window.endMs(), window.speechDensity());
+                continue;
+            }
+            if (window.silencePenalty() > effective.maxSilencePenalty()) {
+                LOGGER.trace("selector skip start={} end={} silencePenalty={} above max", window.startMs(), window.endMs(), window.silencePenalty());
+                continue;
+            }
+
+            double normSpeech = clamp(window.speechDensity());
+            double normConf = clamp(window.avgConfidence());
+            double normEnergy = clamp(window.textEnergy());
+            double normSilence = clamp(1.0 - window.silencePenalty());
+            long keywordMatches = window.keywords() == null ? 0 : window.keywords().size();
+            long userMatches = countUserMatches(window.keywords(), effective.boostKeywords());
+            double keywordBoost = Math.min(0.15, 0.03 * keywordMatches + 0.01 * userMatches);
+
+            double wSpeech = effective.weights().getOrDefault("speech", 0.35);
+            double wConf = effective.weights().getOrDefault("conf", 0.25);
+            double wEnergy = effective.weights().getOrDefault("energy", 0.25);
+            double wSilence = effective.weights().getOrDefault("silence", -0.15);
+            double wKeyword = effective.weights().getOrDefault("keyword", 0.10);
+
+            double score = (wSpeech * normSpeech)
+                    + (wConf * normConf)
+                    + (wEnergy * normEnergy)
+                    + (wSilence * normSilence)
+                    + (wKeyword * keywordBoost);
+
+            scored.add(new ScoredWindow(window, score));
+            String key = keyFor(window);
+            String message = String.format(Locale.ROOT,
+                    "S=%.2f C=%.2f E=%.2f Sil=%.2f kw=%d user=%d -> %.3f",
+                    normSpeech, normConf, normEnergy, window.silencePenalty(), keywordMatches, userMatches, score);
+            explanations.put(key, message);
+            LOGGER.trace("selector window {} score={} details={}", key, String.format(Locale.ROOT, "%.3f", score), message);
+        }
+
+        scored.sort(Comparator.comparingDouble(ScoredWindow::score).reversed());
+        if (scored.size() > limit) {
+            scored = new ArrayList<>(scored.subList(0, limit));
+        }
+        lastExplanation = explanations;
+        LOGGER.debug("HeuristicGoodClipSelector windows={} selected={} topScore={}",
+                windows.size(), scored.size(), scored.isEmpty() ? "-" : String.format(Locale.ROOT, "%.3f", scored.getFirst().score()));
+        return scored;
+    }
+
+    @Override
+    public Map<String, String> explainLast() {
+        return lastExplanation;
+    }
+
+    private static long countUserMatches(Set<String> keywords, Set<String> boostKeywords) {
+        if (keywords == null || boostKeywords == null || boostKeywords.isEmpty()) {
+            return 0;
+        }
+        return keywords.stream().filter(boostKeywords::contains).count();
+    }
+
+    private static String keyFor(Window window) {
+        return window.startMs() + "-" + window.endMs();
+    }
+
+    private static double clamp(double value) {
+        if (Double.isNaN(value)) {
+            return 0.0;
+        }
+        if (value < 0.0) {
+            return 0.0;
+        }
+        if (value > 1.0) {
+            return 1.0;
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/selector/ScoredWindow.java
+++ b/src/main/java/com/example/clipbot_backend/selector/ScoredWindow.java
@@ -1,0 +1,10 @@
+package com.example.clipbot_backend.selector;
+
+/**
+ * Window paired with a calculated score used for ranking.
+ *
+ * @param window window instance containing feature values.
+ * @param score  score between {@code 0.0} and {@code 1.0}.
+ */
+public record ScoredWindow(Window window, double score) {
+}

--- a/src/main/java/com/example/clipbot_backend/selector/SelectorConfig.java
+++ b/src/main/java/com/example/clipbot_backend/selector/SelectorConfig.java
@@ -1,0 +1,37 @@
+package com.example.clipbot_backend.selector;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Configuration for the {@link GoodClipSelector}, including weights and filters.
+ *
+ * @param targetDurationSec preferred window duration in seconds.
+ * @param minSpeechDensity  minimum acceptable speech density.
+ * @param maxSilencePenalty maximum acceptable silence penalty.
+ * @param boostKeywords     keywords that should receive extra attention.
+ * @param weights           weighting map used by the heuristic selector.
+ */
+public record SelectorConfig(int targetDurationSec,
+                             double minSpeechDensity,
+                             double maxSilencePenalty,
+                             Set<String> boostKeywords,
+                             Map<String, Double> weights) {
+
+    private static final Map<String, Double> DEFAULT_WEIGHTS = Map.of(
+            "speech", 0.35,
+            "conf", 0.25,
+            "energy", 0.25,
+            "silence", -0.15,
+            "keyword", 0.10
+    );
+
+    /**
+     * Provides a sensible default configuration tuned for news/podcast content.
+     *
+     * @return selector configuration with balanced weights and thresholds.
+     */
+    public static SelectorConfig defaults() {
+        return new SelectorConfig(25, 0.35, 0.60, Set.of(), DEFAULT_WEIGHTS);
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/selector/Window.java
+++ b/src/main/java/com/example/clipbot_backend/selector/Window.java
@@ -1,0 +1,23 @@
+package com.example.clipbot_backend.selector;
+
+import java.util.Set;
+
+/**
+ * Window features derived from a transcript and segment slice.
+ *
+ * @param startMs        start offset in milliseconds (inclusive).
+ * @param endMs          end offset in milliseconds (exclusive).
+ * @param speechDensity  ratio of spoken audio versus window duration.
+ * @param avgConfidence  average word confidence for spoken tokens.
+ * @param textEnergy     normalized textual energy (words per second + emphasis).
+ * @param silencePenalty penalty for silences where {@code 1.0} means mostly silent.
+ * @param keywords       matched keywords that describe this window.
+ */
+public record Window(long startMs,
+                     long endMs,
+                     double speechDensity,
+                     double avgConfidence,
+                     double textEnergy,
+                     double silencePenalty,
+                     Set<String> keywords) {
+}

--- a/src/main/java/com/example/clipbot_backend/service/RecommendationService.java
+++ b/src/main/java/com/example/clipbot_backend/service/RecommendationService.java
@@ -1,0 +1,46 @@
+package com.example.clipbot_backend.service;
+
+import com.example.clipbot_backend.dto.ClipSummary;
+import com.example.clipbot_backend.dto.RecommendationResult;
+import jakarta.annotation.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Service responsible for generating and listing recommended clips.
+ */
+public interface RecommendationService {
+
+    /**
+     * Computes the top {@code N} clips for the given media and optionally enqueues render jobs.
+     *
+     * @param mediaId       media identifier.
+     * @param topN          number of clips to keep (defaults to six when {@code topN <= 0}).
+     * @param profile       optional render/profile metadata.
+     * @param enqueueRender whether render jobs need to be enqueued immediately.
+     * @return structured recommendation result.
+     */
+    RecommendationResult computeRecommendations(UUID mediaId, int topN, @Nullable Map<String, Object> profile, boolean enqueueRender);
+
+    /**
+     * Lists stored recommendations for a media item.
+     *
+     * @param mediaId media identifier.
+     * @param pageable pagination request with sorting instructions.
+     * @return a page of clip summaries ordered according to {@code pageable}.
+     */
+    Page<ClipSummary> listRecommendations(UUID mediaId, Pageable pageable);
+
+    /**
+     * Provides a debug explanation for a specific window.
+     *
+     * @param mediaId media identifier.
+     * @param startMs start offset of the window.
+     * @param endMs   end offset of the window.
+     * @return explanation map or empty map if unknown.
+     */
+    Map<String, String> explain(UUID mediaId, long startMs, long endMs);
+}

--- a/src/main/java/com/example/clipbot_backend/service/impl/RecommendationServiceImpl.java
+++ b/src/main/java/com/example/clipbot_backend/service/impl/RecommendationServiceImpl.java
@@ -1,0 +1,512 @@
+package com.example.clipbot_backend.service.impl;
+
+import com.example.clipbot_backend.dto.ClipSummary;
+import com.example.clipbot_backend.dto.RecommendationResult;
+import com.example.clipbot_backend.dto.SubtitleFiles;
+import com.example.clipbot_backend.dto.WordsParser;
+import com.example.clipbot_backend.model.Clip;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.model.Segment;
+import com.example.clipbot_backend.model.Transcript;
+import com.example.clipbot_backend.repository.ClipRepository;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.repository.SegmentRepository;
+import com.example.clipbot_backend.repository.TranscriptRepository;
+import com.example.clipbot_backend.selector.GoodClipSelector;
+import com.example.clipbot_backend.selector.ScoredWindow;
+import com.example.clipbot_backend.selector.SelectorConfig;
+import com.example.clipbot_backend.selector.Window;
+import com.example.clipbot_backend.service.JobService;
+import com.example.clipbot_backend.service.RecommendationService;
+import com.example.clipbot_backend.service.Interfaces.SubtitleService;
+import com.example.clipbot_backend.util.ClipStatus;
+import com.example.clipbot_backend.util.JobType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Default implementation of {@link RecommendationService} that builds windows from transcripts and segments.
+ */
+@Service
+public class RecommendationServiceImpl implements RecommendationService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecommendationServiceImpl.class);
+    private static final int DEFAULT_TOP_N = 6;
+    private static final long MIN_WINDOW_MS = 15_000L;
+    private static final long MAX_WINDOW_MS = 60_000L;
+    private static final double DEFAULT_CONFIDENCE = 0.75;
+    private static final double MAX_WORDS_PER_SECOND = 3.5;
+    private static final String DEFAULT_RENDER_PROFILE = "youtube-720p";
+
+    private final MediaRepository mediaRepo;
+    private final ClipRepository clipRepo;
+    private final SegmentRepository segmentRepo;
+    private final TranscriptRepository transcriptRepo;
+    private final SubtitleService subtitleService;
+    private final JobService jobService;
+    private final GoodClipSelector goodClipSelector;
+    private final ObjectMapper objectMapper;
+    private final TransactionTemplate txTemplate;
+
+    public RecommendationServiceImpl(MediaRepository mediaRepo,
+                                     ClipRepository clipRepo,
+                                     SegmentRepository segmentRepo,
+                                     TranscriptRepository transcriptRepo,
+                                     SubtitleService subtitleService,
+                                     JobService jobService,
+                                     GoodClipSelector goodClipSelector,
+                                     ObjectMapper objectMapper,
+                                     TransactionTemplate txTemplate) {
+        this.mediaRepo = mediaRepo;
+        this.clipRepo = clipRepo;
+        this.segmentRepo = segmentRepo;
+        this.transcriptRepo = transcriptRepo;
+        this.subtitleService = subtitleService;
+        this.jobService = jobService;
+        this.goodClipSelector = goodClipSelector;
+        this.objectMapper = objectMapper;
+        this.txTemplate = txTemplate;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RecommendationResult computeRecommendations(UUID mediaId, int topN, @Nullable Map<String, Object> profile, boolean enqueueRender) {
+        Objects.requireNonNull(mediaId, "mediaId");
+        int limit = topN > 0 ? topN : DEFAULT_TOP_N;
+        Map<String, Object> effectiveProfile = profile == null ? Map.of() : profile;
+        long started = System.nanoTime();
+        RecommendationInput input = loadInput(mediaId);
+        SelectorConfig baseCfg = SelectorConfig.defaults();
+        Set<String> keywordPool = deriveKeywords(input.words(), effectiveProfile);
+        SelectorConfig selectorConfig = new SelectorConfig(
+                baseCfg.targetDurationSec(),
+                baseCfg.minSpeechDensity(),
+                baseCfg.maxSilencePenalty(),
+                keywordPool,
+                baseCfg.weights()
+        );
+
+        List<Window> windows = buildWindows(input.media(), input.segments(), input.words(), selectorConfig);
+        List<ScoredWindow> scored = goodClipSelector.selectTop(windows, limit, selectorConfig);
+        LOGGER.info("RecommendationService start media={} windows={} selected={} topScores={}",
+                mediaId,
+                windows.size(),
+                scored.size(),
+                scored.stream().map(sw -> String.format(Locale.ROOT, "%.3f", sw.score())).collect(Collectors.joining(",")));
+
+        List<ClipSummary> summaries = new ArrayList<>();
+        Transcript transcript = input.transcript();
+        String profileHash = computeProfileHash(effectiveProfile);
+        String renderProfile = resolveRenderProfile(effectiveProfile);
+
+        for (ScoredWindow scoredWindow : scored) {
+            Window window = scoredWindow.window();
+            UpsertOutcome outcome = upsertClip(mediaId, profileHash, scoredWindow.score(), window, effectiveProfile);
+            LOGGER.info("RecommendationService upsert clip start={} end={} profileHash={} created={} score={}",
+                    window.startMs(), window.endMs(), profileHash, outcome.created(), outcome.score());
+            summaries.add(new ClipSummary(outcome.clipId(), window.startMs(), window.endMs(), outcome.score(), outcome.status().name(), profileHash));
+
+            if (enqueueRender && outcome.created()) {
+                SubtitleFiles subs = null;
+                if (transcript != null) {
+                    subs = subtitleService.buildSubtitles(transcript, window.startMs(), window.endMs());
+                    if (subs != null) {
+                        LOGGER.info("RecommendationService subtitles built clip={} srtKey={} vttKey={}",
+                                outcome.clipId(), subs.srtKey(), subs.vttKey());
+                    }
+                }
+                enqueueRender(outcome.clipId(), mediaId, renderProfile);
+            } else if (enqueueRender) {
+                LOGGER.info("RecommendationService render skipped clip={} reason=existing", outcome.clipId());
+            }
+        }
+
+        long durationMs = Duration.ofNanos(System.nanoTime() - started).toMillis();
+        LOGGER.info("RecommendationService done media={} clips={} durMs={}", mediaId, summaries.size(), durationMs);
+        return new RecommendationResult(mediaId, summaries.size(), summaries);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Page<ClipSummary> listRecommendations(UUID mediaId, Pageable pageable) {
+        Objects.requireNonNull(mediaId, "mediaId");
+        Pageable effective = pageable == null ? Pageable.unpaged() : pageable;
+        Page<Clip> page = clipRepo.findPageByMediaId(mediaId, effective);
+        List<ClipSummary> summaries = page.getContent().stream()
+                .map(clip -> new ClipSummary(clip.getId(), clip.getStartMs(), clip.getEndMs(), clip.getScore(), clip.getStatus().name(), clip.getProfileHash()))
+                .toList();
+        return new PageImpl<>(summaries, effective, page.getTotalElements());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, String> explain(UUID mediaId, long startMs, long endMs) {
+        Objects.requireNonNull(mediaId, "mediaId");
+        RecommendationInput input = loadInput(mediaId);
+        SelectorConfig baseCfg = SelectorConfig.defaults();
+        Set<String> keywordPool = deriveKeywords(input.words(), Map.of());
+        SelectorConfig selectorConfig = new SelectorConfig(
+                baseCfg.targetDurationSec(),
+                baseCfg.minSpeechDensity(),
+                baseCfg.maxSilencePenalty(),
+                keywordPool,
+                baseCfg.weights()
+        );
+        List<Window> windows = buildWindows(input.media(), input.segments(), input.words(), selectorConfig);
+        if (windows.isEmpty()) {
+            return Map.of();
+        }
+        goodClipSelector.selectTop(windows, windows.size(), selectorConfig);
+        String key = startMs + "-" + endMs;
+        return goodClipSelector.explainLast().entrySet().stream()
+                .filter(entry -> entry.getKey().equals(key))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private void enqueueRender(UUID clipId, UUID mediaId, String profile) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("clipId", clipId.toString());
+        payload.put("profile", profile);
+        jobService.enqueueUnique(mediaId, JobType.CLIP, "clip:" + clipId, payload);
+        LOGGER.info("RecommendationService enqueue render clip={} profile={}", clipId, profile);
+    }
+
+    private UpsertOutcome upsertClip(UUID mediaId, String profileHash, double score, Window window, Map<String, Object> profile) {
+        return txTemplate.execute(status -> {
+            Clip existing = clipRepo.findByMediaIdAndStartMsAndEndMsAndProfileHash(mediaId, window.startMs(), window.endMs(), profileHash)
+                    .orElse(null);
+            BigDecimal newScore = BigDecimal.valueOf(score).setScale(3, RoundingMode.HALF_UP);
+            if (existing != null) {
+                BigDecimal oldScore = existing.getScore();
+                if (oldScore == null || oldScore.compareTo(newScore) < 0) {
+                    existing.setScore(newScore);
+                    clipRepo.save(existing);
+                }
+                return new UpsertOutcome(existing.getId(), existing.getStatus(), newScore, false);
+            }
+
+            Media mediaRef = mediaRepo.getReferenceById(mediaId);
+            Clip clip = new Clip(mediaRef, window.startMs(), window.endMs());
+            clip.setStatus(ClipStatus.QUEUED);
+            clip.setProfileHash(profileHash);
+            clip.setScore(newScore);
+            clip.setMeta(buildMeta(profile));
+            Clip saved = clipRepo.save(clip);
+            return new UpsertOutcome(saved.getId(), saved.getStatus(), newScore, true);
+        });
+    }
+
+    private static Map<String, Object> buildMeta(Map<String, Object> profile) {
+        Map<String, Object> meta = new LinkedHashMap<>();
+        meta.put("source", "auto-reco");
+        if (profile != null && !profile.isEmpty()) {
+            meta.put("profile", profile);
+        }
+        return meta;
+    }
+
+    private static Set<String> deriveKeywords(List<WordsParser.WordAdapter> words, Map<String, Object> profile) {
+        if ((words == null || words.isEmpty()) && (profile == null || profile.get("keywords") == null)) {
+            return Set.of();
+        }
+        Map<String, Integer> counts = new HashMap<>();
+        if (words != null) {
+            for (WordsParser.WordAdapter word : words) {
+                String cleaned = normalizeWord(word.text);
+                if (cleaned.isEmpty()) {
+                    continue;
+                }
+                counts.merge(cleaned, 1, Integer::sum);
+            }
+        }
+        List<Map.Entry<String, Integer>> sorted = counts.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .limit(8)
+                .toList();
+        Set<String> result = new HashSet<>();
+        sorted.forEach(entry -> result.add(entry.getKey()));
+        extractProfileKeywords(profile, result);
+        return Set.copyOf(result);
+    }
+
+    private static void extractProfileKeywords(Map<String, Object> profile, Set<String> target) {
+        if (profile == null || profile.isEmpty()) {
+            return;
+        }
+        Object keywords = profile.get("keywords");
+        if (keywords instanceof Collection<?> collection) {
+            collection.stream()
+                    .map(Object::toString)
+                    .map(RecommendationServiceImpl::normalizeWord)
+                    .filter(s -> !s.isEmpty())
+                    .forEach(target::add);
+        } else if (keywords instanceof String text) {
+            for (String token : text.split(",")) {
+                String cleaned = normalizeWord(token);
+                if (!cleaned.isEmpty()) {
+                    target.add(cleaned);
+                }
+            }
+        }
+    }
+
+    private List<Window> buildWindows(MediaSnapshot media, List<SegmentSnapshot> segments, List<WordsParser.WordAdapter> words, SelectorConfig config) {
+        long targetMs = config.targetDurationSec() * 1000L;
+        long minMs = Math.max(MIN_WINDOW_MS, targetMs - 5_000L);
+        long maxMs = Math.min(MAX_WINDOW_MS, targetMs + 5_000L);
+        long duration = media.durationMs() != null && media.durationMs() > 0 ? media.durationMs() : estimateDuration(segments, words, maxMs);
+        List<Window> windows = new ArrayList<>();
+        Set<String> keywordPool = config.boostKeywords() == null ? Set.of() : config.boostKeywords();
+
+        if (segments != null && !segments.isEmpty()) {
+            for (SegmentSnapshot snapshot : segments) {
+                windows.addAll(fromSegment(snapshot, minMs, maxMs, duration, words, keywordPool));
+            }
+        }
+
+        if (windows.isEmpty()) {
+            windows.addAll(slidingWindows(duration, minMs, maxMs, words, keywordPool));
+        }
+
+        Map<String, Window> deduped = new LinkedHashMap<>();
+        for (Window window : windows) {
+            String key = window.startMs() + ":" + window.endMs();
+            deduped.putIfAbsent(key, window);
+        }
+        return new ArrayList<>(deduped.values());
+    }
+
+    private List<Window> fromSegment(SegmentSnapshot segment, long minMs, long maxMs, long duration, List<WordsParser.WordAdapter> words, Set<String> keywordPool) {
+        List<Window> result = new ArrayList<>();
+        long span = Math.max(segment.endMs() - segment.startMs(), minMs);
+        long windowLength = clamp(span, minMs, maxMs);
+        long start = Math.max(0, segment.startMs() - (windowLength - span) / 2);
+        long end = Math.min(duration, start + windowLength);
+        result.add(buildWindow(start, end, words, keywordPool));
+        if (span > maxMs) {
+            long step = Math.max(minMs, maxMs - 5_000L);
+            for (long offset = segment.startMs(); offset < segment.endMs(); offset += step) {
+                long nextStart = Math.min(offset, Math.max(0, duration - minMs));
+                long nextEnd = Math.min(duration, nextStart + windowLength);
+                if (nextEnd - nextStart >= minMs) {
+                    result.add(buildWindow(nextStart, nextEnd, words, keywordPool));
+                }
+            }
+        }
+        return result;
+    }
+
+    private List<Window> slidingWindows(long duration, long minMs, long maxMs, List<WordsParser.WordAdapter> words, Set<String> keywordPool) {
+        if (duration <= 0) {
+            return List.of();
+        }
+        List<Window> windows = new ArrayList<>();
+        long step = Math.max(minMs, (minMs + maxMs) / 2);
+        for (long start = 0; start < duration; start += step) {
+            long end = Math.min(duration, start + maxMs);
+            if (end - start >= minMs) {
+                windows.add(buildWindow(start, end, words, keywordPool));
+            }
+        }
+        return windows;
+    }
+
+    private Window buildWindow(long start, long end, List<WordsParser.WordAdapter> words, Set<String> keywordPool) {
+        long duration = Math.max(1, end - start);
+        double speechMs = 0.0;
+        double sumConfidence = 0.0;
+        int wordCount = 0;
+        int excitedCount = 0;
+        int uppercaseCount = 0;
+        Set<String> matchedKeywords = new HashSet<>();
+
+        if (words != null) {
+            for (WordsParser.WordAdapter word : words) {
+                long overlapStart = Math.max(start, word.startMs);
+                long overlapEnd = Math.min(end, word.endMs);
+                if (overlapEnd <= overlapStart) {
+                    continue;
+                }
+                speechMs += overlapEnd - overlapStart;
+                double confidence = word.confidence == null ? DEFAULT_CONFIDENCE : word.confidence;
+                sumConfidence += confidence;
+                wordCount++;
+                String text = word.text == null ? "" : word.text;
+                if (text.matches(".*[!?].*")) {
+                    excitedCount++;
+                }
+                if (text.chars().anyMatch(Character::isUpperCase)) {
+                    uppercaseCount++;
+                }
+                String normalized = normalizeWord(text);
+                if (!normalized.isEmpty() && keywordPool.contains(normalized)) {
+                    matchedKeywords.add(normalized);
+                }
+            }
+        }
+
+        double speechDensity = clampDouble(speechMs / duration);
+        double avgConfidence = wordCount == 0 ? 0.0 : clampDouble(sumConfidence / wordCount);
+        double wordsPerSecond = wordCount / Math.max(1.0, duration / 1000.0);
+        double energy = clampDouble((wordsPerSecond / MAX_WORDS_PER_SECOND) + Math.min(0.2, excitedCount * 0.05 + uppercaseCount * 0.02));
+        double silencePenalty = clampDouble(1.0 - speechDensity);
+        return new Window(start, end, speechDensity, avgConfidence, energy, silencePenalty, Set.copyOf(matchedKeywords));
+    }
+
+    private static long estimateDuration(List<SegmentSnapshot> segments, List<WordsParser.WordAdapter> words, long fallback) {
+        long max = fallback;
+        if (segments != null) {
+            for (SegmentSnapshot snapshot : segments) {
+                max = Math.max(max, snapshot.endMs());
+            }
+        }
+        if (words != null) {
+            for (WordsParser.WordAdapter word : words) {
+                max = Math.max(max, word.endMs);
+            }
+        }
+        return max;
+    }
+
+    private static long clamp(long value, long min, long max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private static double clampDouble(double value) {
+        if (Double.isNaN(value)) {
+            return 0.0;
+        }
+        if (value < 0.0) {
+            return 0.0;
+        }
+        if (value > 1.0) {
+            return 1.0;
+        }
+        return value;
+    }
+
+    private static String normalizeWord(String text) {
+        if (text == null) {
+            return "";
+        }
+        String normalized = text.replaceAll("[^a-zA-Z0-9]", "").toLowerCase(Locale.ROOT);
+        return normalized.length() < 4 ? "" : normalized;
+    }
+
+    private String computeProfileHash(Map<String, Object> profile) {
+        if (profile == null || profile.isEmpty()) {
+            return "";
+        }
+        try {
+            Object canonical = canonicalize(profile);
+            String json = objectMapper.writeValueAsString(canonical);
+            MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            byte[] hash = digest.digest(json.getBytes(StandardCharsets.UTF_8));
+            StringBuilder builder = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                builder.append(String.format(Locale.ROOT, "%02x", b));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-1 unavailable", e);
+        } catch (Exception e) {
+            throw new IllegalStateException("PROFILE_HASH_FAILED", e);
+        }
+    }
+
+    private static Object canonicalize(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> sorted = new TreeMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (entry.getKey() == null) {
+                    continue;
+                }
+                sorted.put(entry.getKey().toString(), canonicalize(entry.getValue()));
+            }
+            return sorted;
+        }
+        if (value instanceof Collection<?> collection) {
+            List<Object> normalized = new ArrayList<>(collection.size());
+            for (Object item : collection) {
+                normalized.add(canonicalize(item));
+            }
+            return normalized;
+        }
+        return value;
+    }
+
+    private static String resolveRenderProfile(Map<String, Object> profile) {
+        if (profile != null) {
+            Object profileValue = profile.get("profile");
+            if (profileValue instanceof String text && !text.isBlank()) {
+                return text;
+            }
+        }
+        return DEFAULT_RENDER_PROFILE;
+    }
+
+    @Transactional(readOnly = true)
+    protected RecommendationInput loadInput(UUID mediaId) {
+        Media media = mediaRepo.findById(mediaId).orElseThrow(() -> new IllegalArgumentException("MEDIA_NOT_FOUND"));
+        List<Segment> rawSegments = segmentRepo.findByMedia(media, Pageable.unpaged()).getContent();
+        List<SegmentSnapshot> segments = rawSegments.stream()
+                .map(segment -> new SegmentSnapshot(segment.getStartMs(), segment.getEndMs()))
+                .toList();
+        Transcript transcript = transcriptRepo.findTopByMediaIdOrderByCreatedAtDesc(mediaId).orElse(null);
+        if (transcript != null && transcript.getMedia() != null) {
+            transcript.getMedia().getId();
+        }
+        List<WordsParser.WordAdapter> words = WordsParser.extract(transcript);
+        MediaSnapshot mediaSnapshot = new MediaSnapshot(media.getId(), media.getDurationMs());
+        return new RecommendationInput(mediaSnapshot, transcript, segments, words);
+    }
+
+    private record RecommendationInput(MediaSnapshot media,
+                                       Transcript transcript,
+                                       List<SegmentSnapshot> segments,
+                                       List<WordsParser.WordAdapter> words) {
+    }
+
+    private record MediaSnapshot(UUID id, Long durationMs) {
+    }
+
+    private record SegmentSnapshot(long startMs, long endMs) {
+    }
+
+    private record UpsertOutcome(UUID clipId, ClipStatus status, BigDecimal score, boolean created) {
+    }
+}

--- a/src/main/resources/db/migration/V21__clip_profile_hash_and_render_stats.sql
+++ b/src/main/resources/db/migration/V21__clip_profile_hash_and_render_stats.sql
@@ -1,3 +1,6 @@
+-- V21__clip_profile_hash_and_render_stats.sql
+
+-- 1) Nieuwe kolommen
 ALTER TABLE clip
     ADD COLUMN IF NOT EXISTS profile_hash TEXT;
 
@@ -12,20 +15,68 @@ ALTER TABLE clip
 ALTER TABLE clip
     ADD COLUMN IF NOT EXISTS score NUMERIC(6,3);
 
-WITH ranked AS (
-    SELECT id,
-           ROW_NUMBER() OVER (
-               PARTITION BY media_id, start_ms, end_ms, profile_hash
-               ORDER BY created_at NULLS LAST, id
-           ) AS rn
-    FROM clip
+-- 2a) Repoint FK's van duplicates -> keeper (CTE per statement!)
+WITH grp AS (
+    SELECT
+        c.id,
+        c.media_id,
+        c.start_ms,
+        c.end_ms,
+        c.profile_hash,
+        c.created_at,
+        ROW_NUMBER() OVER (
+            PARTITION BY c.media_id, c.start_ms, c.end_ms, c.profile_hash
+            ORDER BY c.created_at NULLS LAST, c.id
+        ) AS rn,
+        FIRST_VALUE(c.id) OVER (
+            PARTITION BY c.media_id, c.start_ms, c.end_ms, c.profile_hash
+            ORDER BY c.created_at NULLS LAST, c.id
+        ) AS keep_id
+    FROM clip c
+),
+dups AS (
+    SELECT id AS old_id, keep_id
+    FROM grp
+    WHERE rn > 1 AND id <> keep_id
 )
-DELETE FROM clip
-WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+UPDATE asset a
+SET related_clip_id = d.keep_id
+FROM dups d
+WHERE a.related_clip_id = d.old_id;
 
+-- 2b) Verwijder duplicates (CTE opnieuw definiëren)
+WITH grp AS (
+    SELECT
+        c.id,
+        c.media_id,
+        c.start_ms,
+        c.end_ms,
+        c.profile_hash,
+        c.created_at,
+        ROW_NUMBER() OVER (
+            PARTITION BY c.media_id, c.start_ms, c.end_ms, c.profile_hash
+            ORDER BY c.created_at NULLS LAST, c.id
+        ) AS rn,
+        FIRST_VALUE(c.id) OVER (
+            PARTITION BY c.media_id, c.start_ms, c.end_ms, c.profile_hash
+            ORDER BY c.created_at NULLS LAST, c.id
+        ) AS keep_id
+    FROM clip c
+),
+dups AS (
+    SELECT id AS old_id
+    FROM grp
+    WHERE rn > 1 AND id <> keep_id
+)
+DELETE FROM clip c
+USING dups d
+WHERE c.id = d.old_id;
+
+-- 3) Unieke index afdwingen
 CREATE UNIQUE INDEX IF NOT EXISTS ux_clip_media_range_profile
     ON clip(media_id, start_ms, end_ms, profile_hash);
 
+-- 4) Render stats tabel
 CREATE TABLE IF NOT EXISTS render_stats (
     id UUID PRIMARY KEY,
     kind TEXT NOT NULL,

--- a/src/test/java/com/example/clipbot_backend/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/example/clipbot_backend/controller/RecommendationControllerTest.java
@@ -12,7 +12,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.MockitoBean;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
@@ -43,9 +43,9 @@ class RecommendationControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private RecommendationService recommendationService;
-    @MockBean
+    @MockitoBean
     private MediaRepository mediaRepository;
 
     @Test

--- a/src/test/java/com/example/clipbot_backend/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/example/clipbot_backend/controller/RecommendationControllerTest.java
@@ -12,10 +12,11 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockitoBean;
+
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/example/clipbot_backend/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/example/clipbot_backend/controller/RecommendationControllerTest.java
@@ -1,0 +1,120 @@
+package com.example.clipbot_backend.controller;
+
+import com.example.clipbot_backend.dto.ClipSummary;
+import com.example.clipbot_backend.dto.RecommendationResult;
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.service.RecommendationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = RecommendationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class RecommendationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private RecommendationService recommendationService;
+    @MockBean
+    private MediaRepository mediaRepository;
+
+    @Test
+    void computeEndpointTriggersService() throws Exception {
+        UUID mediaId = UUID.randomUUID();
+        Media media = buildMedia("user-1");
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media));
+        RecommendationResult result = new RecommendationResult(mediaId, 1,
+                List.of(new ClipSummary(UUID.randomUUID(), 0, 20_000, BigDecimal.valueOf(0.9), "QUEUED", "abc")));
+        when(recommendationService.computeRecommendations(eq(mediaId), eq(3), any(), eq(true))).thenReturn(result);
+
+        String body = objectMapper.writeValueAsString(Map.of(
+                "topN", 3,
+                "profile", Map.of("profile", "youtube-720p"),
+                "enqueueRender", true
+        ));
+
+        mockMvc.perform(post("/v1/media/{mediaId}/recommendations/compute", mediaId)
+                        .param("ownerExternalSubject", "user-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(1));
+    }
+
+    @Test
+    void listEndpointReturnsPagedClips() throws Exception {
+        UUID mediaId = UUID.randomUUID();
+        Media media = buildMedia("owner-subj");
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media));
+        ClipSummary summary = new ClipSummary(UUID.randomUUID(), 1000, 8000, BigDecimal.valueOf(0.5), "READY", "hash");
+        when(recommendationService.listRecommendations(eq(mediaId), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(summary)));
+
+        mockMvc.perform(get("/v1/media/{mediaId}/recommendations", mediaId)
+                        .param("page", "1")
+                        .param("size", "2")
+                        .param("sort", "score,desc")
+                        .param("ownerExternalSubject", "owner-subj"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].status").value("READY"));
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(recommendationService).listRecommendations(eq(mediaId), pageableCaptor.capture());
+        assertThat(pageableCaptor.getValue().getPageNumber()).isEqualTo(1);
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(2);
+        assertThat(pageableCaptor.getValue().getSort().getOrderFor("score")).isNotNull();
+    }
+
+    @Test
+    void explainEndpointReturnsBreakdown() throws Exception {
+        UUID mediaId = UUID.randomUUID();
+        Media media = buildMedia("owner");
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media));
+        when(recommendationService.explain(mediaId, 1000L, 5000L)).thenReturn(Map.of("1000-5000", "details"));
+
+        mockMvc.perform(get("/v1/media/{mediaId}/recommendations/explain", mediaId)
+                        .param("startMs", "1000")
+                        .param("endMs", "5000")
+                        .param("ownerExternalSubject", "owner"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.['1000-5000']").value("details"));
+    }
+
+    private static Media buildMedia(String ownerSubject) {
+        Media media = new Media();
+        Account owner = new Account();
+        owner.setExternalSubject(ownerSubject);
+        media.setOwner(owner);
+        return media;
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/selector/HeuristicGoodClipSelectorTest.java
+++ b/src/test/java/com/example/clipbot_backend/selector/HeuristicGoodClipSelectorTest.java
@@ -1,0 +1,36 @@
+package com.example.clipbot_backend.selector;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HeuristicGoodClipSelectorTest {
+
+    private final HeuristicGoodClipSelector selector = new HeuristicGoodClipSelector();
+
+    @Test
+    void selectsTopWindowsUsingDeterministicRanking() {
+        SelectorConfig base = SelectorConfig.defaults();
+        SelectorConfig cfg = new SelectorConfig(base.targetDurationSec(), base.minSpeechDensity(), base.maxSilencePenalty(), Set.of("launch", "market"), base.weights());
+        Window w1 = new Window(0, 20_000, 0.60, 0.80, 0.50, 0.20, Set.of("launch"));
+        Window w2 = new Window(5_000, 25_000, 0.82, 0.85, 0.70, 0.10, Set.of("market", "launch"));
+        Window w3 = new Window(10_000, 30_000, 0.20, 0.60, 0.40, 0.90, Set.of()); // should be filtered (silence)
+        Window w4 = new Window(15_000, 35_000, 0.58, 0.78, 0.55, 0.25, Set.of("growth"));
+
+        List<ScoredWindow> result = selector.selectTop(List.of(w1, w2, w3, w4), 3, cfg);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).window()).isEqualTo(w2);
+        assertThat(result.get(1).window()).isEqualTo(w1);
+        assertThat(result.get(2).window()).isEqualTo(w4);
+        assertThat(result.stream().map(ScoredWindow::window)).doesNotContain(w3);
+
+        Map<String, String> explain = selector.explainLast();
+        assertThat(explain).containsKey("5000-25000");
+        assertThat(explain.get("5000-25000")).contains("kw=2");
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/service/RecommendationServiceImplTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/RecommendationServiceImplTest.java
@@ -23,7 +23,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.transaction.support.PseudoTransactionManager;
+
+
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
@@ -43,6 +49,24 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+
+class PseudoTransactionManager implements PlatformTransactionManager {
+
+    @Override
+    public TransactionStatus getTransaction(TransactionDefinition definition) throws TransactionException {
+        return new SimpleTransactionStatus();
+    }
+
+    @Override
+    public void commit(TransactionStatus status) throws TransactionException {
+        // niets
+    }
+
+    @Override
+    public void rollback(TransactionStatus status) throws TransactionException {
+        // niets
+    }
+}
 @ExtendWith(MockitoExtension.class)
 class RecommendationServiceImplTest {
 

--- a/src/test/java/com/example/clipbot_backend/service/RecommendationServiceImplTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/RecommendationServiceImplTest.java
@@ -1,0 +1,121 @@
+package com.example.clipbot_backend.service;
+
+import com.example.clipbot_backend.dto.RecommendationResult;
+import com.example.clipbot_backend.dto.SubtitleFiles;
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Clip;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.model.Segment;
+import com.example.clipbot_backend.model.Transcript;
+import com.example.clipbot_backend.repository.ClipRepository;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.repository.SegmentRepository;
+import com.example.clipbot_backend.repository.TranscriptRepository;
+import com.example.clipbot_backend.selector.HeuristicGoodClipSelector;
+import com.example.clipbot_backend.service.Interfaces.SubtitleService;
+import com.example.clipbot_backend.service.impl.RecommendationServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.ResourcelessTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationServiceImplTest {
+
+    @Mock
+    private MediaRepository mediaRepository;
+    @Mock
+    private ClipRepository clipRepository;
+    @Mock
+    private SegmentRepository segmentRepository;
+    @Mock
+    private TranscriptRepository transcriptRepository;
+    @Mock
+    private SubtitleService subtitleService;
+    @Mock
+    private JobService jobService;
+
+    private RecommendationServiceImpl service;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        TransactionTemplate template = new TransactionTemplate(new ResourcelessTransactionManager());
+        service = new RecommendationServiceImpl(mediaRepository, clipRepository, segmentRepository, transcriptRepository,
+                subtitleService, jobService, new HeuristicGoodClipSelector(), objectMapper, template);
+    }
+
+    @Test
+    void computeRecommendationsIsIdempotentAndAvoidsDoubleEnqueue() throws Exception {
+        UUID mediaId = UUID.randomUUID();
+        Media media = new Media();
+        media.setId(mediaId);
+        Account owner = new Account();
+        owner.setExternalSubject("user");
+        media.setOwner(owner);
+
+        Segment segment = new Segment(media, 0L, 25_000L);
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media));
+        when(mediaRepository.getReferenceById(mediaId)).thenReturn(media);
+        when(segmentRepository.findByMedia(eq(media), eq(Pageable.unpaged()))).thenReturn(new PageImpl<>(List.of(segment)));
+
+        Transcript transcript = new Transcript();
+        transcript.setMedia(media);
+        transcript.setWords(objectMapper.readTree("{" +
+                "\"items\":[{" +
+                "\"text\":\"Hello\",\"startMs\":0,\"endMs\":1000,\"confidence\":0.9},{" +
+                "\"text\":\"world!\",\"startMs\":1000,\"endMs\":2500,\"confidence\":0.8}]}"));
+        when(transcriptRepository.findTopByMediaIdOrderByCreatedAtDesc(mediaId)).thenReturn(Optional.of(transcript));
+
+        AtomicReference<Clip> storedClip = new AtomicReference<>();
+        when(clipRepository.findByMediaIdAndStartMsAndEndMsAndProfileHash(eq(mediaId), anyLong(), anyLong(), anyString()))
+                .then(invocation -> storedClip.get() == null ? Optional.empty() : Optional.of(storedClip.get()));
+        when(clipRepository.save(any(Clip.class))).thenAnswer(invocation -> {
+            Clip clip = invocation.getArgument(0);
+            if (clip.getId() == null) {
+                ReflectionTestUtils.setField(clip, "id", UUID.randomUUID());
+            }
+            storedClip.set(clip);
+            return clip;
+        });
+        when(subtitleService.buildSubtitles(any(), anyLong(), anyLong()))
+                .thenReturn(new SubtitleFiles("key.srt", 10L, "key.vtt", 11L));
+        when(jobService.enqueueUnique(eq(mediaId), eq(com.example.clipbot_backend.util.JobType.CLIP), anyString(), anyMap()))
+                .thenReturn(UUID.randomUUID());
+
+        RecommendationResult first = service.computeRecommendations(mediaId, 1, Map.of("profile", "youtube-720p"), true);
+        RecommendationResult second = service.computeRecommendations(mediaId, 1, Map.of("profile", "youtube-720p"), true);
+
+        assertThat(first.clips()).hasSize(1);
+        assertThat(second.clips()).hasSize(1);
+        assertThat(second.clips().getFirst().id()).isEqualTo(first.clips().getFirst().id());
+
+        verify(jobService, times(1)).enqueueUnique(eq(mediaId), eq(com.example.clipbot_backend.util.JobType.CLIP), anyString(), anyMap());
+        verify(subtitleService, times(1)).buildSubtitles(any(), anyLong(), anyLong());
+        verifyNoMoreInteractions(jobService);
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/service/RecommendationServiceImplTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/RecommendationServiceImplTest.java
@@ -23,7 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.transaction.support.ResourcelessTransactionManager;
+import org.springframework.transaction.support.PseudoTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
@@ -64,7 +64,7 @@ class RecommendationServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        TransactionTemplate template = new TransactionTemplate(new ResourcelessTransactionManager());
+        TransactionTemplate template = new TransactionTemplate(new PseudoTransactionManager());
         service = new RecommendationServiceImpl(mediaRepository, clipRepository, segmentRepository, transcriptRepository,
                 subtitleService, jobService, new HeuristicGoodClipSelector(), objectMapper, template);
     }


### PR DESCRIPTION
## Summary
- add a reusable selector module with scoring records/configuration and a heuristic implementation
- implement the recommendation service/controller, DTOs and repository helpers plus switch the default render profile to youtube-720p
- cover the new selector, service idempotency and controller endpoints with dedicated tests

## Testing
- `./mvnw -q test` *(fails: Maven wrapper cannot download the Maven binary in this environment)*
- `mvn -q test` *(fails: cannot download the Spring Boot parent POM from Maven Central in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dfdb66be88331babfe0573c252c93)