### PR TITLE
Add one-click orchestration endpoint

### DIFF
--- a/docs/postman-one-click.md
+++ b/docs/postman-one-click.md
@@ -45,3 +45,4 @@ Deze gids laat zien hoe je de idempotente one-click orchestrator met Postman kun
 ## Tips
 - Houd `ownerExternalSubject` consistent per testrun; idempotency wordt op owner + key afgedwongen.
 - Voor uploads gebruik je `mediaId` in plaats van `url`; de fingerprint-check werkt hetzelfde: gewijzigde payload met dezelfde key geeft 409.
+- Genereer de `idempotencyKey` in de client (bijv. `crypto.randomUUID()` in de frontend) en hergebruik die alleen voor retries met dezelfde payload; een nieuwe bron of upload hoort een nieuwe key te krijgen.

--- a/docs/postman-one-click.md
+++ b/docs/postman-one-click.md
@@ -1,0 +1,47 @@
+# One-click orchestrator: Postman test flow
+
+Deze gids laat zien hoe je de idempotente one-click orchestrator met Postman kunt testen, inclusief de request-fingerprint check die een 409 geeft wanneer dezelfde idempotency key met een andere payload wordt hergebruikt.
+
+## Basisinstellingen
+- **Endpoint**: `POST http://localhost:8080/v1/orchestrate/one-click`
+- **Headers**: `Content-Type: application/json`
+- **Verplichte velden**: `ownerExternalSubject`, exact één van `url` of `mediaId`, en `idempotencyKey`.
+
+## Scenario 1: Eerste succesvolle call
+1. Maak een nieuwe **POST** request met body:
+   ```json
+   {
+     "ownerExternalSubject": "demo-user-1",
+     "url": "https://www.youtube.com/watch?v=dNgFOGzuOqE",
+     "title": "My YT import",
+     "opts": {
+       "lang": "auto",
+       "provider": "fasterwhisper",
+       "sceneThreshold": 0.3,
+       "topN": 6,
+       "enqueueRender": true
+     },
+     "idempotencyKey": "11111111-1111-4111-8111-111111111111"
+   }
+   ```
+2. Verwacht een **200** met o.a. `projectId`, `mediaId`, `detectJob`, `recommendations`, `thumbnailSource`, en eventueel `renderJobs`.
+
+## Scenario 2: Replay met dezelfde payload
+1. Stuur exact dezelfde request opnieuw met **dezelfde** `idempotencyKey` (`1111...`).
+2. Verwacht wederom een **200** met **identieke** response-body; er wordt geen nieuwe detect- of render-job gestart (replay uit de idempotency store).
+
+## Scenario 3: Bescherming tegen payload-wijziging
+1. Pas de body aan (bijvoorbeeld verander `url` of `opts.topN`) maar laat `idempotencyKey` ongewijzigd (`1111...`).
+2. Verwacht een **409** response. De orchestrator vergelijkt de opgeslagen request-fingerprint met de nieuwe payload en wijst de key af als de inhoud verschilt.
+
+## Scenario 4: Nieuwe workload met nieuwe key
+1. Gebruik dezelfde gewijzigde payload als in scenario 3, maar geef een **nieuwe** `idempotencyKey` (bijv. `22222222-2222-4222-8222-222222222222`).
+2. Verwacht een **200** en een nieuwe orchestratie (nieuwe `mediaId`/`projectId` of reuse waar van toepassing).
+
+## Optioneel: voortgang controleren
+- Gebruik `GET http://localhost:8080/v1/jobs/{detectJob.jobId}` om de detect-jobstatus te volgen.
+- Herhaal totdat `status` op **SUCCEEDED** staat; daarna zullen aanbevelingen/renders (indien geënqueue'd) worden verwerkt.
+
+## Tips
+- Houd `ownerExternalSubject` consistent per testrun; idempotency wordt op owner + key afgedwongen.
+- Voor uploads gebruik je `mediaId` in plaats van `url`; de fingerprint-check werkt hetzelfde: gewijzigde payload met dezelfde key geeft 409.

--- a/src/main/java/com/example/clipbot_backend/controller/OneClickController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/OneClickController.java
@@ -1,0 +1,37 @@
+package com.example.clipbot_backend.controller;
+
+import com.example.clipbot_backend.dto.orchestrate.OneClickRequest;
+import com.example.clipbot_backend.dto.orchestrate.OneClickResponse;
+import com.example.clipbot_backend.service.OneClickOrchestrator;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * HTTP endpoint for the one-click orchestration flow.
+ */
+@RestController
+@RequestMapping("/v1/orchestrate")
+public class OneClickController {
+    private final OneClickOrchestrator orchestrator;
+
+    public OneClickController(OneClickOrchestrator orchestrator) {
+        this.orchestrator = orchestrator;
+    }
+
+    @Operation(summary = "Run full ingest + detect + recommend flow in one call")
+    @ApiResponse(responseCode = "200", description = "Orchestration completed successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request payload")
+    @ApiResponse(responseCode = "409", description = "Idempotency conflict or in-progress orchestration")
+    @PostMapping("/one-click")
+    public ResponseEntity<OneClickResponse> oneClick(@Valid @RequestBody OneClickRequest request) {
+        OneClickResponse response = orchestrator.orchestrate(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/dto/ProjectPatch.java
+++ b/src/main/java/com/example/clipbot_backend/dto/ProjectPatch.java
@@ -1,0 +1,85 @@
+package com.example.clipbot_backend.dto;
+
+import java.util.Objects;
+
+/**
+ * Patch container for partial project updates.
+ */
+public class ProjectPatch {
+    private final String title;
+    private final String thumbnailUrl;
+    private final String normalizedSourceUrl;
+
+    private ProjectPatch(Builder builder) {
+        this.title = builder.title;
+        this.thumbnailUrl = builder.thumbnailUrl;
+        this.normalizedSourceUrl = builder.normalizedSourceUrl;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public String thumbnailUrl() {
+        return thumbnailUrl;
+    }
+
+    public String normalizedSourceUrl() {
+        return normalizedSourceUrl;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String title;
+        private String thumbnailUrl;
+        private String normalizedSourceUrl;
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder thumbnailUrl(String thumbnailUrl) {
+            this.thumbnailUrl = thumbnailUrl;
+            return this;
+        }
+
+        public Builder normalizedSourceUrl(String normalizedSourceUrl) {
+            this.normalizedSourceUrl = normalizedSourceUrl;
+            return this;
+        }
+
+        public ProjectPatch build() {
+            if (title == null && thumbnailUrl == null && normalizedSourceUrl == null) {
+                throw new IllegalStateException("ProjectPatch requires at least one field to be set");
+            }
+            return new ProjectPatch(this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ProjectPatch{" +
+                "title='" + title + '\'' +
+                ", thumbnailUrl='" + thumbnailUrl + '\'' +
+                ", normalizedSourceUrl='" + normalizedSourceUrl + '\'' +
+                '}';
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(title, thumbnailUrl, normalizedSourceUrl);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof ProjectPatch other)) return false;
+        return Objects.equals(title, other.title)
+                && Objects.equals(thumbnailUrl, other.thumbnailUrl)
+                && Objects.equals(normalizedSourceUrl, other.normalizedSourceUrl);
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/dto/media/CreateFromUrlResponse.java
+++ b/src/main/java/com/example/clipbot_backend/dto/media/CreateFromUrlResponse.java
@@ -1,0 +1,9 @@
+package com.example.clipbot_backend.dto.media;
+
+import java.util.UUID;
+
+/**
+ * Minimal response for media creation from URL.
+ */
+public record CreateFromUrlResponse(UUID mediaId) {
+}

--- a/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickJob.java
+++ b/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickJob.java
@@ -1,0 +1,9 @@
+package com.example.clipbot_backend.dto.orchestrate;
+
+import java.util.UUID;
+
+/**
+ * Minimal job view used in the one-click response.
+ */
+public record OneClickJob(UUID jobId, String status) {
+}

--- a/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickRecommendation.java
+++ b/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickRecommendation.java
@@ -1,0 +1,7 @@
+package com.example.clipbot_backend.dto.orchestrate;
+
+/**
+ * Captures recommendation counts.
+ */
+public record OneClickRecommendation(int requested, int computed) {
+}

--- a/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickRenderJob.java
+++ b/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickRenderJob.java
@@ -1,0 +1,9 @@
+package com.example.clipbot_backend.dto.orchestrate;
+
+import java.util.UUID;
+
+/**
+ * Render job representation returned to the client.
+ */
+public record OneClickRenderJob(UUID clipId, UUID jobId, String status) {
+}

--- a/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickRequest.java
@@ -1,0 +1,43 @@
+package com.example.clipbot_backend.dto.orchestrate;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+/**
+ * Request payload for the one-click orchestration endpoint.
+ */
+public record OneClickRequest(
+        @NotBlank String ownerExternalSubject,
+        String url,
+        UUID mediaId,
+        String title,
+        Options opts,
+        @NotBlank String idempotencyKey
+) {
+    /**
+     * User-supplied options with sensible defaults applied by the orchestrator.
+     */
+    public record Options(String lang, String provider, Double sceneThreshold, Integer topN, Boolean enqueueRender) {
+        public String normalizedLang() {
+            return lang != null && !lang.isBlank() ? lang.trim() : null;
+        }
+
+        public String normalizedProvider() {
+            return provider != null && !provider.isBlank() ? provider.trim() : null;
+        }
+
+        public Double normalizedSceneThreshold() {
+            return sceneThreshold;
+        }
+
+        public int resolvedTopN(int fallback) {
+            return topN != null && topN > 0 ? topN : fallback;
+        }
+
+        public boolean shouldEnqueueRender(boolean fallback) {
+            return enqueueRender == null ? fallback : enqueueRender;
+        }
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickResponse.java
+++ b/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickResponse.java
@@ -1,0 +1,126 @@
+package com.example.clipbot_backend.dto.orchestrate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Response payload emitted by the one-click orchestration flow.
+ */
+public class OneClickResponse {
+    private UUID projectId;
+    private UUID mediaId;
+    private boolean createdProject;
+    private OneClickJob detectJob;
+    private OneClickRecommendation recommendations;
+    private List<OneClickRenderJob> renderJobs = new ArrayList<>();
+    private String thumbnailSource;
+
+    public UUID getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(UUID projectId) {
+        this.projectId = projectId;
+    }
+
+    public UUID getMediaId() {
+        return mediaId;
+    }
+
+    public void setMediaId(UUID mediaId) {
+        this.mediaId = mediaId;
+    }
+
+    public boolean isCreatedProject() {
+        return createdProject;
+    }
+
+    public void setCreatedProject(boolean createdProject) {
+        this.createdProject = createdProject;
+    }
+
+    public OneClickJob getDetectJob() {
+        return detectJob;
+    }
+
+    public void setDetectJob(OneClickJob detectJob) {
+        this.detectJob = detectJob;
+    }
+
+    public OneClickRecommendation getRecommendations() {
+        return recommendations;
+    }
+
+    public void setRecommendations(OneClickRecommendation recommendations) {
+        this.recommendations = recommendations;
+    }
+
+    public List<OneClickRenderJob> getRenderJobs() {
+        return renderJobs;
+    }
+
+    public void setRenderJobs(List<OneClickRenderJob> renderJobs) {
+        this.renderJobs = renderJobs == null ? List.of() : renderJobs;
+    }
+
+    public String getThumbnailSource() {
+        return thumbnailSource;
+    }
+
+    public void setThumbnailSource(String thumbnailSource) {
+        this.thumbnailSource = thumbnailSource;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final OneClickResponse instance = new OneClickResponse();
+
+        public Builder projectId(UUID projectId) {
+            instance.setProjectId(projectId);
+            return this;
+        }
+
+        public Builder mediaId(UUID mediaId) {
+            instance.setMediaId(mediaId);
+            return this;
+        }
+
+        public Builder createdProject(boolean createdProject) {
+            instance.setCreatedProject(createdProject);
+            return this;
+        }
+
+        public Builder detectJob(OneClickJob detectJob) {
+            instance.setDetectJob(detectJob);
+            return this;
+        }
+
+        public Builder recommendations(OneClickRecommendation recommendations) {
+            instance.setRecommendations(recommendations);
+            return this;
+        }
+
+        public Builder renderJobs(List<OneClickRenderJob> renderJobs) {
+            instance.setRenderJobs(renderJobs);
+            return this;
+        }
+
+        public Builder thumbnailSource(String thumbnailSource) {
+            instance.setThumbnailSource(thumbnailSource);
+            return this;
+        }
+
+        public OneClickResponse build() {
+            Objects.requireNonNull(instance.getProjectId(), "projectId");
+            Objects.requireNonNull(instance.getMediaId(), "mediaId");
+            Objects.requireNonNull(instance.getDetectJob(), "detectJob");
+            Objects.requireNonNull(instance.getRecommendations(), "recommendations");
+            return instance;
+        }
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/model/OneClickOrchestration.java
+++ b/src/main/java/com/example/clipbot_backend/model/OneClickOrchestration.java
@@ -1,0 +1,108 @@
+package com.example.clipbot_backend.model;
+
+import com.example.clipbot_backend.util.OrchestrationStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Persists idempotent one-click orchestration calls to ensure replayability.
+ */
+@Entity
+@Table(name = "one_click_orchestration", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_orchestration_owner_key", columnNames = {"owner_external_subject", "idempotency_key"})
+})
+public class OneClickOrchestration {
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "owner_external_subject", nullable = false, length = 255)
+    private String ownerExternalSubject;
+
+    @Column(name = "idempotency_key", nullable = false, length = 255)
+    private String idempotencyKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private OrchestrationStatus status = OrchestrationStatus.IN_PROGRESS;
+
+    @Lob
+    @Column(name = "response_payload")
+    private String responsePayload;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    public OneClickOrchestration() {
+    }
+
+    public OneClickOrchestration(String ownerExternalSubject, String idempotencyKey) {
+        this.ownerExternalSubject = ownerExternalSubject;
+        this.idempotencyKey = idempotencyKey;
+        this.status = OrchestrationStatus.IN_PROGRESS;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getOwnerExternalSubject() {
+        return ownerExternalSubject;
+    }
+
+    public void setOwnerExternalSubject(String ownerExternalSubject) {
+        this.ownerExternalSubject = ownerExternalSubject;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public void setIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public OrchestrationStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OrchestrationStatus status) {
+        this.status = status;
+    }
+
+    public String getResponsePayload() {
+        return responsePayload;
+    }
+
+    public void setResponsePayload(String responsePayload) {
+        this.responsePayload = responsePayload;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/model/OneClickOrchestration.java
+++ b/src/main/java/com/example/clipbot_backend/model/OneClickOrchestration.java
@@ -7,7 +7,6 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import org.hibernate.annotations.CreationTimestamp;
@@ -41,8 +40,7 @@ public class OneClickOrchestration {
     @Column(name = "status", nullable = false, length = 32)
     private OrchestrationStatus status = OrchestrationStatus.IN_PROGRESS;
 
-    @Lob
-    @Column(name = "response_payload")
+    @Column(name = "response_payload", columnDefinition = "text")
     private String responsePayload;
 
     @CreationTimestamp

--- a/src/main/java/com/example/clipbot_backend/model/OneClickOrchestration.java
+++ b/src/main/java/com/example/clipbot_backend/model/OneClickOrchestration.java
@@ -43,6 +43,9 @@ public class OneClickOrchestration {
     @Column(name = "response_payload", columnDefinition = "text")
     private String responsePayload;
 
+    @Column(name = "request_fingerprint", length = 512)
+    private String requestFingerprint;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -94,6 +97,14 @@ public class OneClickOrchestration {
 
     public void setResponsePayload(String responsePayload) {
         this.responsePayload = responsePayload;
+    }
+
+    public String getRequestFingerprint() {
+        return requestFingerprint;
+    }
+
+    public void setRequestFingerprint(String requestFingerprint) {
+        this.requestFingerprint = requestFingerprint;
     }
 
     public Instant getCreatedAt() {

--- a/src/main/java/com/example/clipbot_backend/model/Project.java
+++ b/src/main/java/com/example/clipbot_backend/model/Project.java
@@ -24,6 +24,12 @@ public class Project {
     @Column(name = "title", nullable = false, length = 255)
     private String title;
 
+    @Column(name = "normalized_source_url", length = 2048)
+    private String normalizedSourceUrl;
+
+    @Column(name = "thumbnail_url", length = 2048)
+    private String thumbnailUrl;
+
     @Column(name = "template_id", nullable = true)
     private UUID templateId;
 
@@ -42,6 +48,11 @@ public class Project {
         this.owner = owner;
         this.title = title;
         this.templateId = templateId;
+    }
+
+    public Project(Account owner, String title, UUID templateId, String normalizedSourceUrl) {
+        this(owner, title, templateId);
+        this.normalizedSourceUrl = normalizedSourceUrl;
     }
 
     public UUID getId() {
@@ -70,6 +81,22 @@ public class Project {
 
     public void setTemplateId(UUID templateId) {
         this.templateId = templateId;
+    }
+
+    public String getNormalizedSourceUrl() {
+        return normalizedSourceUrl;
+    }
+
+    public void setNormalizedSourceUrl(String normalizedSourceUrl) {
+        this.normalizedSourceUrl = normalizedSourceUrl;
+    }
+
+    public String getThumbnailUrl() {
+        return thumbnailUrl;
+    }
+
+    public void setThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
     }
 
     public Instant getCreatedAt() {

--- a/src/main/java/com/example/clipbot_backend/repository/OneClickOrchestrationRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/OneClickOrchestrationRepository.java
@@ -1,0 +1,11 @@
+package com.example.clipbot_backend.repository;
+
+import com.example.clipbot_backend.model.OneClickOrchestration;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OneClickOrchestrationRepository extends JpaRepository<OneClickOrchestration, UUID> {
+    Optional<OneClickOrchestration> findByOwnerExternalSubjectAndIdempotencyKey(String ownerExternalSubject, String idempotencyKey);
+}

--- a/src/main/java/com/example/clipbot_backend/repository/ProjectRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/ProjectRepository.java
@@ -5,9 +5,16 @@ import com.example.clipbot_backend.model.Project;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.UUID;
+import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, UUID> {
     Page<Project> findByOwnerOrderByCreatedAtDesc(Account owner, Pageable pageable);
+
+    @Query("select p from Project p where p.owner.externalSubject = :ownerExternalSubject and p.normalizedSourceUrl = :normalizedUrl")
+    Optional<Project> findByOwnerAndNormalizedUrl(@Param("ownerExternalSubject") String ownerExternalSubject,
+                                                 @Param("normalizedUrl") String normalizedUrl);
 }

--- a/src/main/java/com/example/clipbot_backend/repository/SegmentRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/SegmentRepository.java
@@ -24,4 +24,6 @@ public interface SegmentRepository extends JpaRepository<Segment, UUID> {
     @Transactional
     @Query("delete from Segment s where s.media = :media")
     int deleteByMedia(@Param("media") Media media);
+
+    long countByMediaId(UUID mediaId);
 }

--- a/src/main/java/com/example/clipbot_backend/service/DetectionService.java
+++ b/src/main/java/com/example/clipbot_backend/service/DetectionService.java
@@ -42,11 +42,22 @@ public class DetectionService {
     }
 
     public UUID enqueueDetect(UUID mediaId, String lang, String provider, Double sceneThreshold){
+        return enqueueDetect(mediaId, lang, provider, sceneThreshold, null, null);
+    }
+
+    public UUID enqueueDetect(UUID mediaId,
+                              String lang,
+                              String provider,
+                              Double sceneThreshold,
+                              Integer topN,
+                              Boolean enqueueRender) {
         Media media = mediaRepo.findById(mediaId).orElseThrow();
-        Map<String,Object> payload = new LinkedHashMap<>();
+        Map<String, Object> payload = new LinkedHashMap<>();
         if (lang != null) payload.put("lang", lang);
         if (provider != null) payload.put("provider", provider);
         if (sceneThreshold != null) payload.put("sceneThreshold", sceneThreshold);
+        if (topN != null) payload.put("topN", topN);
+        if (enqueueRender != null) payload.put("enqueueRender", enqueueRender);
         return jobService.enqueue(media.getId(), JobType.DETECT, payload);
     }
 

--- a/src/main/java/com/example/clipbot_backend/service/MediaService.java
+++ b/src/main/java/com/example/clipbot_backend/service/MediaService.java
@@ -155,7 +155,7 @@ public class MediaService  {
         String s = (source == null ? "" : source.trim().toLowerCase());
         return switch (s) {
             case "upload" -> "upload";
-            case "url", "" -> "url";
+            case "url", "ingest", "" -> "url";
             default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_SOURCE");
         };
     }

--- a/src/main/java/com/example/clipbot_backend/service/MediaService.java
+++ b/src/main/java/com/example/clipbot_backend/service/MediaService.java
@@ -2,6 +2,7 @@ package com.example.clipbot_backend.service;
 
 import com.example.clipbot_backend.model.Media;
 
+import com.example.clipbot_backend.dto.media.CreateFromUrlResponse;
 import com.example.clipbot_backend.repository.MediaRepository;
 import com.example.clipbot_backend.util.MediaPlatform;
 import com.example.clipbot_backend.util.MediaStatus;
@@ -109,6 +110,11 @@ public class MediaService  {
 
         mediaRepo.save(media);
         return media.getId();
+    }
+
+    public CreateFromUrlResponse createFromUrl(UUID ownerId, String url, String source) {
+        UUID mediaId = createMediaFromUrl(ownerId, url, MediaPlatform.OTHER, source, null, null);
+        return new CreateFromUrlResponse(mediaId);
     }
 
     private String buildExternalObjectKey(String url, MediaPlatform platform) {

--- a/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
+++ b/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
@@ -113,7 +113,11 @@ public class OneClickOrchestrator {
             LOGGER.info("OneClickOrchestrator DONE owner={} projectId={} mediaId={} idempotencyKey={}",
                     request.ownerExternalSubject(), projectResolution.project().getId(), mediaId, request.idempotencyKey());
             return response;
-        } catch (RuntimeException | ResponseStatusException ex) {
+        } catch (ResponseStatusException ex) {
+            orchestration.setStatus(OrchestrationStatus.FAILED);
+            orchestrationRepository.save(orchestration);
+            throw ex;
+        } catch (RuntimeException ex) {
             orchestration.setStatus(OrchestrationStatus.FAILED);
             orchestrationRepository.save(orchestration);
             throw ex;

--- a/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
+++ b/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
@@ -1,0 +1,264 @@
+package com.example.clipbot_backend.service;
+
+import com.example.clipbot_backend.dto.ProjectPatch;
+import com.example.clipbot_backend.dto.media.CreateFromUrlResponse;
+import com.example.clipbot_backend.dto.orchestrate.OneClickJob;
+import com.example.clipbot_backend.dto.orchestrate.OneClickRecommendation;
+import com.example.clipbot_backend.dto.orchestrate.OneClickRequest;
+import com.example.clipbot_backend.dto.orchestrate.OneClickResponse;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.model.OneClickOrchestration;
+import com.example.clipbot_backend.model.Project;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.repository.OneClickOrchestrationRepository;
+import com.example.clipbot_backend.service.metadata.MetadataResult;
+import com.example.clipbot_backend.service.metadata.MetadataService;
+import com.example.clipbot_backend.util.MediaPlatform;
+import com.example.clipbot_backend.util.OrchestrationStatus;
+import com.example.clipbot_backend.util.ThumbnailSource;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Service that orchestrates the complete ingest + detect + recommend flow in a single call.
+ */
+@Service
+public class OneClickOrchestrator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OneClickOrchestrator.class);
+    private static final int DEFAULT_TOP_N = 6;
+
+    private final MetadataService metadataService;
+    private final ProjectService projectService;
+    private final MediaService mediaService;
+    private final MediaRepository mediaRepository;
+    private final DetectionService detectionService;
+    private final RecommendationService recommendationService;
+    private final OneClickOrchestrationRepository orchestrationRepository;
+    private final ObjectMapper objectMapper;
+
+    public OneClickOrchestrator(MetadataService metadataService,
+                                ProjectService projectService,
+                                MediaService mediaService,
+                                MediaRepository mediaRepository,
+                                DetectionService detectionService,
+                                RecommendationService recommendationService,
+                                OneClickOrchestrationRepository orchestrationRepository,
+                                ObjectMapper objectMapper) {
+        this.metadataService = metadataService;
+        this.projectService = projectService;
+        this.mediaService = mediaService;
+        this.mediaRepository = mediaRepository;
+        this.detectionService = detectionService;
+        this.recommendationService = recommendationService;
+        this.orchestrationRepository = orchestrationRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Runs the orchestration flow atomically with idempotency protection.
+     *
+     * @param request validated request payload.
+     * @return orchestration response with identifiers and job details.
+     */
+    @Transactional
+    public OneClickResponse orchestrate(OneClickRequest request) {
+        validateRequest(request);
+        LOGGER.info("OneClickOrchestrator START owner={} idempotencyKey={}", request.ownerExternalSubject(), request.idempotencyKey());
+
+        OneClickOrchestration orchestration = orchestrationRepository
+                .findByOwnerExternalSubjectAndIdempotencyKey(request.ownerExternalSubject(), request.idempotencyKey())
+                .map(existing -> handleExistingOrchestration(existing, request))
+                .orElseGet(() -> createOrchestrationRecord(request));
+
+        if (orchestration.getStatus() == OrchestrationStatus.SUCCEEDED && orchestration.getResponsePayload() != null) {
+            return deserialize(orchestration.getResponsePayload());
+        }
+
+        try {
+            MetadataResult metadata = resolveMetadata(request);
+            String resolvedTitle = resolveTitle(request, metadata);
+            ProjectResolution projectResolution = resolveProject(request.ownerExternalSubject(), metadata, resolvedTitle);
+
+            UUID mediaId = resolveMedia(request, metadata, projectResolution.project());
+            linkMedia(projectResolution.project().getId(), mediaId, request.ownerExternalSubject());
+
+            OneClickRequest.Options options = request.opts() == null ? new OneClickRequest.Options(null, null, null, null, null) : request.opts();
+            OneClickJob detectJob = enqueueDetect(mediaId, options);
+            OneClickRecommendation recs = enqueueRecommendations(mediaId, request.ownerExternalSubject(), options);
+
+            ThumbnailSource thumbnailSource = applyThumbnailIfPresent(projectResolution.project().getId(), metadata);
+
+            OneClickResponse response = OneClickResponse.builder()
+                    .projectId(projectResolution.project().getId())
+                    .mediaId(mediaId)
+                    .createdProject(projectResolution.created())
+                    .detectJob(detectJob)
+                    .recommendations(recs)
+                    .renderJobs(Collections.emptyList())
+                    .thumbnailSource(thumbnailSource.name())
+                    .build();
+
+            orchestration.setStatus(OrchestrationStatus.SUCCEEDED);
+            orchestration.setResponsePayload(serialize(response));
+            orchestrationRepository.save(orchestration);
+            LOGGER.info("OneClickOrchestrator DONE owner={} projectId={} mediaId={} idempotencyKey={}",
+                    request.ownerExternalSubject(), projectResolution.project().getId(), mediaId, request.idempotencyKey());
+            return response;
+        } catch (RuntimeException | ResponseStatusException ex) {
+            orchestration.setStatus(OrchestrationStatus.FAILED);
+            orchestrationRepository.save(orchestration);
+            throw ex;
+        }
+    }
+
+    private MetadataResult resolveMetadata(OneClickRequest request) {
+        if (request.url() == null || request.url().isBlank()) {
+            return null;
+        }
+        try {
+            return metadataService.resolve(request.url());
+        } catch (ResponseStatusException ex) {
+            LOGGER.warn("Metadata resolve failed url={} reason={} status={}", request.url(), ex.getReason(), ex.getStatusCode());
+            throw ex;
+        }
+    }
+
+    private String resolveTitle(OneClickRequest request, MetadataResult metadata) {
+        if (request.title() != null && !request.title().isBlank()) {
+            return request.title().trim();
+        }
+        if (metadata != null && metadata.title() != null && !metadata.title().isBlank()) {
+            return metadata.title();
+        }
+        return "New project";
+    }
+
+    private ProjectResolution resolveProject(String ownerExternalSubject, MetadataResult metadata, String title) {
+        String normalizedUrl = metadata != null ? metadata.url() : null;
+        Optional<Project> existing = projectService.findByNormalizedUrl(ownerExternalSubject, normalizedUrl);
+        if (existing.isPresent()) {
+            Project project = existing.get();
+            LOGGER.info("OneClickOrchestrator reuseProject owner={} projectId={} normalizedUrl={}", ownerExternalSubject, project.getId(), normalizedUrl);
+            return new ProjectResolution(project, false);
+        }
+        Project created = projectService.createProjectBySubject(ownerExternalSubject, title, null, normalizedUrl);
+        return new ProjectResolution(created, true);
+    }
+
+    private UUID resolveMedia(OneClickRequest request, MetadataResult metadata, Project project) {
+        if (request.mediaId() != null) {
+            Media media = mediaRepository.findById(request.mediaId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "MEDIA_NOT_FOUND"));
+            String ownerSubject = media.getOwner() != null ? media.getOwner().getExternalSubject() : null;
+            if (!request.ownerExternalSubject().equals(ownerSubject)) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "MEDIA_NOT_OWNED");
+            }
+            return media.getId();
+        }
+        if (request.url() == null || request.url().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "URL_REQUIRED");
+        }
+
+        MediaPlatform platform = metadata != null ? metadata.platform() : MediaPlatform.OTHER;
+        Long durationMs = metadata != null && metadata.durationSec() != null ? metadata.durationSec() * 1000 : null;
+        CreateFromUrlResponse created = new CreateFromUrlResponse(
+                mediaService.createMediaFromUrl(project.getOwner().getId(),
+                        metadata != null ? metadata.url() : request.url(),
+                        platform,
+                        "ingest",
+                        durationMs,
+                        null)
+        );
+        return created.mediaId();
+    }
+
+    private void linkMedia(UUID projectId, UUID mediaId, String ownerExternalSubject) {
+        projectService.linkMediaStrict(projectId, mediaId);
+        LOGGER.info("OneClickOrchestrator linked media owner={} projectId={} mediaId={}", ownerExternalSubject, projectId, mediaId);
+    }
+
+    private OneClickJob enqueueDetect(UUID mediaId, OneClickRequest.Options options) {
+        String lang = options.normalizedLang();
+        String provider = options.normalizedProvider();
+        Double sceneThreshold = options.normalizedSceneThreshold();
+        UUID jobId = detectionService.enqueueDetect(mediaId, lang == null ? "auto" : lang, provider == null ? "fasterwhisper" : provider, sceneThreshold);
+        return new OneClickJob(jobId, "ENQUEUED");
+    }
+
+    private OneClickRecommendation enqueueRecommendations(UUID mediaId, String ownerExternalSubject, OneClickRequest.Options options) {
+        int requested = options.resolvedTopN(DEFAULT_TOP_N);
+        boolean enqueueRender = options.shouldEnqueueRender(true);
+        int computed = recommendationService.computeRecommendations(mediaId, requested, null, enqueueRender).count();
+        LOGGER.info("OneClickOrchestrator recommendations owner={} mediaId={} requested={} computed={} enqueueRender={}", ownerExternalSubject, mediaId, requested, computed, enqueueRender);
+        return new OneClickRecommendation(requested, computed);
+    }
+
+    private ThumbnailSource applyThumbnailIfPresent(UUID projectId, MetadataResult metadata) {
+        if (metadata != null && metadata.platform() == MediaPlatform.YOUTUBE && metadata.thumbnail() != null) {
+            projectService.patch(projectId, ProjectPatch.builder().thumbnailUrl(metadata.thumbnail()).build());
+            return ThumbnailSource.YOUTUBE;
+        }
+        return ThumbnailSource.NONE;
+    }
+
+    private OneClickOrchestration createOrchestrationRecord(OneClickRequest request) {
+        OneClickOrchestration orchestration = new OneClickOrchestration(request.ownerExternalSubject(), request.idempotencyKey());
+        orchestrationRepository.save(orchestration);
+        return orchestration;
+    }
+
+    private OneClickOrchestration handleExistingOrchestration(OneClickOrchestration orchestration, OneClickRequest request) {
+        if (!request.ownerExternalSubject().equals(orchestration.getOwnerExternalSubject())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "IDEMPOTENCY_OWNER_MISMATCH");
+        }
+        if (orchestration.getStatus() == OrchestrationStatus.IN_PROGRESS) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "ORCHESTRATION_IN_PROGRESS");
+        }
+        return orchestration;
+    }
+
+    private void validateRequest(OneClickRequest request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "REQUEST_REQUIRED");
+        }
+        if (request.ownerExternalSubject() == null || request.ownerExternalSubject().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "OWNER_REQUIRED");
+        }
+        boolean hasUrl = request.url() != null && !request.url().isBlank();
+        boolean hasMedia = request.mediaId() != null;
+        if (hasUrl == hasMedia) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "URL_XOR_MEDIA_ID_REQUIRED");
+        }
+        if (request.idempotencyKey() == null || request.idempotencyKey().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "IDEMPOTENCY_KEY_REQUIRED");
+        }
+    }
+
+    private String serialize(OneClickResponse response) {
+        try {
+            return objectMapper.writeValueAsString(response);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to serialize response", ex);
+        }
+    }
+
+    private OneClickResponse deserialize(String json) {
+        try {
+            return objectMapper.readValue(json, OneClickResponse.class);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to deserialize stored response", ex);
+        }
+    }
+
+    private record ProjectResolution(Project project, boolean created) {
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/util/AssetKind.java
+++ b/src/main/java/com/example/clipbot_backend/util/AssetKind.java
@@ -1,10 +1,45 @@
 package com.example.clipbot_backend.util;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enumerates the supported asset kinds that can be persisted.
+ */
 public enum AssetKind {
     MEDIA_RAW,
     MP4,
     WEBM,
     THUMBNAIL,
     SUB_SRT,
-    SUB_VTT
+    SUB_VTT;
+
+    /**
+     * Allows tolerant, case-insensitive deserialization from JSON to prevent 400 errors on valid input.
+     *
+     * @param value incoming value from the request payload.
+     * @return matching {@link AssetKind}.
+     */
+    @JsonCreator
+    public static AssetKind fromJson(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        for (AssetKind kind : values()) {
+            if (kind.name().equalsIgnoreCase(value.trim())) {
+                return kind;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported AssetKind: " + value);
+    }
+
+    /**
+     * Serializes the enum using its name to keep payloads stable.
+     *
+     * @return canonical JSON value.
+     */
+    @JsonValue
+    public String toJson() {
+        return name();
+    }
 }

--- a/src/main/java/com/example/clipbot_backend/util/OrchestrationStatus.java
+++ b/src/main/java/com/example/clipbot_backend/util/OrchestrationStatus.java
@@ -1,0 +1,10 @@
+package com.example.clipbot_backend.util;
+
+/**
+ * Tracks lifecycle of an orchestrated one-click operation.
+ */
+public enum OrchestrationStatus {
+    IN_PROGRESS,
+    SUCCEEDED,
+    FAILED
+}

--- a/src/main/java/com/example/clipbot_backend/util/ThumbnailSource.java
+++ b/src/main/java/com/example/clipbot_backend/util/ThumbnailSource.java
@@ -1,0 +1,10 @@
+package com.example.clipbot_backend.util;
+
+/**
+ * Indicates how a project thumbnail was sourced during orchestration.
+ */
+public enum ThumbnailSource {
+    YOUTUBE,
+    CLIP,
+    NONE
+}

--- a/src/main/resources/db/migration/V24__one_click_orchestration.sql
+++ b/src/main/resources/db/migration/V24__one_click_orchestration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS one_click_orchestration (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    owner_external_subject VARCHAR(255) NOT NULL,
+    idempotency_key VARCHAR(255) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    response_payload TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ,
+    CONSTRAINT uk_orchestration_owner_key UNIQUE (owner_external_subject, idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_orchestration_owner ON one_click_orchestration(owner_external_subject, created_at);

--- a/src/main/resources/db/migration/V25__add_normalized_source_url_to_project.sql
+++ b/src/main/resources/db/migration/V25__add_normalized_source_url_to_project.sql
@@ -1,0 +1,6 @@
+-- Ensure projects can store the normalized source URL used for reuse heuristics
+ALTER TABLE project
+    ADD COLUMN IF NOT EXISTS normalized_source_url VARCHAR(2048);
+
+CREATE INDEX IF NOT EXISTS idx_project_normalized_source_url
+    ON project (normalized_source_url);

--- a/src/main/resources/db/migration/V26__add_thumbnail_url_to_project.sql
+++ b/src/main/resources/db/migration/V26__add_thumbnail_url_to_project.sql
@@ -1,0 +1,6 @@
+-- Adds thumbnail_url to project to align with entity mapping
+ALTER TABLE project
+    ADD COLUMN IF NOT EXISTS thumbnail_url VARCHAR(2048);
+
+-- Optional index if queries filter on thumbnail presence; safe no-op when absent
+CREATE INDEX IF NOT EXISTS idx_project_thumbnail_url ON project(thumbnail_url);

--- a/src/main/resources/db/migration/V27__align_orchestrator_schema.sql
+++ b/src/main/resources/db/migration/V27__align_orchestrator_schema.sql
@@ -1,0 +1,11 @@
+-- Aligns project and one-click orchestration schema with entity mappings and lookup patterns
+-- 1) Normalize column type for response payload to text (idempotent when already text)
+ALTER TABLE one_click_orchestration
+    ALTER COLUMN response_payload TYPE TEXT;
+
+-- 2) Ensure normalized_source_url can hold full values and is indexed with owner for reuse lookups
+ALTER TABLE project
+    ALTER COLUMN normalized_source_url TYPE VARCHAR(2048);
+
+CREATE INDEX IF NOT EXISTS idx_project_owner_normalized_source_url
+    ON project(owner_id, normalized_source_url);

--- a/src/main/resources/db/migration/V28__add_request_fingerprint.sql
+++ b/src/main/resources/db/migration/V28__add_request_fingerprint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE one_click_orchestration
+    ADD COLUMN IF NOT EXISTS request_fingerprint VARCHAR(512);

--- a/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
@@ -1,0 +1,198 @@
+package com.example.clipbot_backend.service;
+
+import com.example.clipbot_backend.dto.orchestrate.OneClickJob;
+import com.example.clipbot_backend.dto.orchestrate.OneClickRequest;
+import com.example.clipbot_backend.dto.orchestrate.OneClickResponse;
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.OneClickOrchestration;
+import com.example.clipbot_backend.model.Project;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.repository.OneClickOrchestrationRepository;
+import com.example.clipbot_backend.service.metadata.MetadataResult;
+import com.example.clipbot_backend.service.metadata.MetadataService;
+import com.example.clipbot_backend.util.MediaPlatform;
+import com.example.clipbot_backend.util.OrchestrationStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OneClickOrchestratorTest {
+
+    @Mock
+    private MetadataService metadataService;
+    @Mock
+    private ProjectService projectService;
+    @Mock
+    private MediaService mediaService;
+    @Mock
+    private MediaRepository mediaRepository;
+    @Mock
+    private DetectionService detectionService;
+    @Mock
+    private RecommendationService recommendationService;
+    @Mock
+    private OneClickOrchestrationRepository orchestrationRepository;
+
+    private ObjectMapper objectMapper;
+
+    private OneClickOrchestrator orchestrator;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        orchestrator = new OneClickOrchestrator(
+                metadataService,
+                projectService,
+                mediaService,
+                mediaRepository,
+                detectionService,
+                recommendationService,
+                orchestrationRepository,
+                objectMapper
+        );
+        when(orchestrationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    void orchestrateCreatesProjectFromUrlAndEnqueuesFlow() {
+        UUID mediaId = UUID.randomUUID();
+        UUID projectId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Account owner = new Account();
+        owner.setId(UUID.randomUUID());
+        owner.setExternalSubject("demo-user");
+        Project project = new Project(owner, "My import", null, "https://normalized");
+        project.setId(projectId);
+
+        OneClickRequest request = new OneClickRequest(
+                owner.getExternalSubject(),
+                "https://youtube.com/watch?v=abc",
+                null,
+                "My import",
+                new OneClickRequest.Options("auto", "fasterwhisper", 0.3, 6, true),
+                "idem-1"
+        );
+
+        MetadataResult metadata = new MetadataResult(MediaPlatform.YOUTUBE, "https://normalized", "Meta title", "auth", 120L, "thumb");
+        when(metadataService.resolve(anyString())).thenReturn(metadata);
+        when(orchestrationRepository.findByOwnerExternalSubjectAndIdempotencyKey(anyString(), anyString()))
+                .thenReturn(Optional.empty());
+        when(projectService.findByNormalizedUrl(anyString(), anyString())).thenReturn(Optional.empty());
+        when(projectService.createProjectBySubject(anyString(), anyString(), any(), any())).thenReturn(project);
+        when(mediaService.createMediaFromUrl(any(), any(), any(), anyString(), any(), any())).thenReturn(mediaId);
+        when(detectionService.enqueueDetect(any(), anyString(), anyString(), any())).thenReturn(jobId);
+        when(recommendationService.computeRecommendations(any(), anyInt(), any(), any())).thenReturn(new com.example.clipbot_backend.dto.RecommendationResult(mediaId, 2, java.util.List.of()));
+
+        OneClickResponse response = orchestrator.orchestrate(request);
+
+        assertThat(response.getProjectId()).isEqualTo(projectId);
+        assertThat(response.getMediaId()).isEqualTo(mediaId);
+        assertThat(response.isCreatedProject()).isTrue();
+        assertThat(response.getDetectJob()).isEqualTo(new OneClickJob(jobId, "ENQUEUED"));
+        assertThat(response.getRecommendations().computed()).isEqualTo(2);
+        assertThat(response.getThumbnailSource()).isEqualTo("YOUTUBE");
+
+        verify(projectService).patch(projectId, org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void orchestrateUsesExistingMediaId() {
+        UUID mediaId = UUID.randomUUID();
+        UUID projectId = UUID.randomUUID();
+        UUID ownerId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Account owner = new Account();
+        owner.setId(ownerId);
+        owner.setExternalSubject("demo-user");
+        Project project = new Project(owner, "New project", null, null);
+        project.setId(projectId);
+
+        com.example.clipbot_backend.model.Media media = new com.example.clipbot_backend.model.Media();
+        media.setId(mediaId);
+        media.setOwner(owner);
+
+        OneClickRequest request = new OneClickRequest(
+                owner.getExternalSubject(),
+                null,
+                mediaId,
+                null,
+                new OneClickRequest.Options(null, null, null, null, null),
+                "idem-2"
+        );
+
+        when(projectService.findByNormalizedUrl(anyString(), any())).thenReturn(Optional.empty());
+        when(orchestrationRepository.findByOwnerExternalSubjectAndIdempotencyKey(anyString(), anyString()))
+                .thenReturn(Optional.empty());
+        when(projectService.createProjectBySubject(anyString(), anyString(), any(), any())).thenReturn(project);
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media));
+        when(detectionService.enqueueDetect(any(), anyString(), anyString(), any())).thenReturn(jobId);
+        when(recommendationService.computeRecommendations(any(), anyInt(), any(), any())).thenReturn(new com.example.clipbot_backend.dto.RecommendationResult(mediaId, 1, java.util.List.of()));
+
+        OneClickResponse response = orchestrator.orchestrate(request);
+
+        assertThat(response.getMediaId()).isEqualTo(mediaId);
+        assertThat(response.isCreatedProject()).isTrue();
+        verify(mediaService, never()).createMediaFromUrl(any(), any(), any(), anyString(), any(), any());
+    }
+
+    @Test
+    void orchestrateReplaysSuccessfulIdempotentCall() {
+        UUID mediaId = UUID.randomUUID();
+        UUID projectId = UUID.randomUUID();
+        OneClickResponse stored = OneClickResponse.builder()
+                .projectId(projectId)
+                .mediaId(mediaId)
+                .createdProject(true)
+                .detectJob(new OneClickJob(UUID.randomUUID(), "ENQUEUED"))
+                .recommendations(new com.example.clipbot_backend.dto.orchestrate.OneClickRecommendation(6, 6))
+                .renderJobs(java.util.List.of())
+                .thumbnailSource("NONE")
+                .build();
+        OneClickOrchestration entity = new OneClickOrchestration("demo", "idem-3");
+        entity.setStatus(OrchestrationStatus.SUCCEEDED);
+        try {
+            entity.setResponsePayload(objectMapper.writeValueAsString(stored));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        OneClickRequest request = new OneClickRequest("demo", "https://example.com", null, null, null, "idem-3");
+
+        when(orchestrationRepository.findByOwnerExternalSubjectAndIdempotencyKey("demo", "idem-3"))
+                .thenReturn(Optional.of(entity));
+
+        OneClickResponse response = orchestrator.orchestrate(request);
+
+        assertThat(response.getProjectId()).isEqualTo(projectId);
+        verify(detectionService, never()).enqueueDetect(any(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void orchestrateValidatesExclusiveInputs() {
+        OneClickRequest request = new OneClickRequest("demo", "https://example.com", UUID.randomUUID(), null, null, "idem-4");
+
+        assertThatThrownBy(() -> orchestrator.orchestrate(request))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("URL_XOR_MEDIA_ID_REQUIRED")
+                .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
@@ -8,6 +8,8 @@ import com.example.clipbot_backend.model.OneClickOrchestration;
 import com.example.clipbot_backend.model.Project;
 import com.example.clipbot_backend.repository.MediaRepository;
 import com.example.clipbot_backend.repository.OneClickOrchestrationRepository;
+import com.example.clipbot_backend.repository.SegmentRepository;
+import com.example.clipbot_backend.repository.TranscriptRepository;
 import com.example.clipbot_backend.service.metadata.MetadataResult;
 import com.example.clipbot_backend.service.metadata.MetadataService;
 import com.example.clipbot_backend.util.MediaPlatform;
@@ -49,6 +51,10 @@ class OneClickOrchestratorTest {
     @Mock
     private RecommendationService recommendationService;
     @Mock
+    private SegmentRepository segmentRepository;
+    @Mock
+    private TranscriptRepository transcriptRepository;
+    @Mock
     private OneClickOrchestrationRepository orchestrationRepository;
 
     private ObjectMapper objectMapper;
@@ -65,6 +71,8 @@ class OneClickOrchestratorTest {
                 mediaRepository,
                 detectionService,
                 recommendationService,
+                segmentRepository,
+                transcriptRepository,
                 orchestrationRepository,
                 objectMapper
         );
@@ -98,7 +106,9 @@ class OneClickOrchestratorTest {
         when(projectService.findByNormalizedUrl(anyString(), anyString())).thenReturn(Optional.empty());
         when(projectService.createProjectBySubject(anyString(), anyString(), any(), any())).thenReturn(project);
         when(mediaService.createMediaFromUrl(any(), any(), any(), anyString(), any(), any())).thenReturn(mediaId);
-        when(detectionService.enqueueDetect(any(), anyString(), anyString(), any())).thenReturn(jobId);
+        when(detectionService.enqueueDetect(any(), anyString(), anyString(), any(), any(), any())).thenReturn(jobId);
+        when(transcriptRepository.existsByMediaId(mediaId)).thenReturn(true);
+        when(segmentRepository.countByMediaId(mediaId)).thenReturn(3L);
         when(recommendationService.computeRecommendations(any(), anyInt(), any(), any())).thenReturn(new com.example.clipbot_backend.dto.RecommendationResult(mediaId, 2, java.util.List.of()));
 
         OneClickResponse response = orchestrator.orchestrate(request);
@@ -143,7 +153,9 @@ class OneClickOrchestratorTest {
                 .thenReturn(Optional.empty());
         when(projectService.createProjectBySubject(anyString(), anyString(), any(), any())).thenReturn(project);
         when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media));
-        when(detectionService.enqueueDetect(any(), anyString(), anyString(), any())).thenReturn(jobId);
+        when(detectionService.enqueueDetect(any(), anyString(), anyString(), any(), any(), any())).thenReturn(jobId);
+        when(transcriptRepository.existsByMediaId(mediaId)).thenReturn(true);
+        when(segmentRepository.countByMediaId(mediaId)).thenReturn(2L);
         when(recommendationService.computeRecommendations(any(), anyInt(), any(), any())).thenReturn(new com.example.clipbot_backend.dto.RecommendationResult(mediaId, 1, java.util.List.of()));
 
         OneClickResponse response = orchestrator.orchestrate(request);
@@ -182,7 +194,7 @@ class OneClickOrchestratorTest {
         OneClickResponse response = orchestrator.orchestrate(request);
 
         assertThat(response.getProjectId()).isEqualTo(projectId);
-        verify(detectionService, never()).enqueueDetect(any(), anyString(), anyString(), any());
+        verify(detectionService, never()).enqueueDetect(any(), anyString(), anyString(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add one-click orchestration controller/service with idempotency tracking and metadata-aware project/media handling
- introduce DTOs, repositories, and enums to support orchestration responses, thumbnails, and asset deserialization
- extend project/media services plus tests covering URL and media-id flows and idempotency replay

## Testing
- mvn -q test *(fails: project pom references itself, preventing build)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692857e06bc483319dbc14d6b25271ed)