### PR TITLE
Enhance one-click upload orchestration

### DIFF
--- a/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickRequest.java
@@ -1,7 +1,6 @@
 package com.example.clipbot_backend.dto.orchestrate;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
@@ -14,7 +13,8 @@ public record OneClickRequest(
         UUID mediaId,
         String title,
         Options opts,
-        @NotBlank String idempotencyKey
+        @NotBlank String idempotencyKey,
+        UUID projectId
 ) {
     /**
      * User-supplied options with sensible defaults applied by the orchestrator.

--- a/src/main/java/com/example/clipbot_backend/model/OneClickOrchestration.java
+++ b/src/main/java/com/example/clipbot_backend/model/OneClickOrchestration.java
@@ -46,6 +46,9 @@ public class OneClickOrchestration {
     @Column(name = "request_fingerprint", length = 512)
     private String requestFingerprint;
 
+    @Column(name = "started_at")
+    private Instant startedAt;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -113,5 +116,13 @@ public class OneClickOrchestration {
 
     public Instant getUpdatedAt() {
         return updatedAt;
+    }
+
+    public Instant getStartedAt() {
+        return startedAt;
+    }
+
+    public void setStartedAt(Instant startedAt) {
+        this.startedAt = startedAt;
     }
 }

--- a/src/main/java/com/example/clipbot_backend/repository/ProjectMediaRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/ProjectMediaRepository.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 public interface ProjectMediaRepository extends JpaRepository<ProjectMediaLink, ProjectMediaId> {
     boolean existsByProjectAndMedia(Project project, Media media);
     List<ProjectMediaLink> findByProject(Project project);
+    List<ProjectMediaLink> findByMedia(Media media);
 
     @Query("""
            select pml.media

--- a/src/main/java/com/example/clipbot_backend/service/ClipWorkFlow.java
+++ b/src/main/java/com/example/clipbot_backend/service/ClipWorkFlow.java
@@ -9,6 +9,7 @@ import com.example.clipbot_backend.model.*;
 import com.example.clipbot_backend.repository.*;
 import com.example.clipbot_backend.service.Interfaces.StorageService;
 import com.example.clipbot_backend.service.Interfaces.SubtitleService;
+import com.example.clipbot_backend.service.thumbnail.ThumbnailService;
 import com.example.clipbot_backend.util.AssetKind;
 import com.example.clipbot_backend.util.ClipStatus;
 import jakarta.annotation.Nullable;
@@ -36,6 +37,8 @@ public class ClipWorkFlow {
     private final SubtitleService subtitles;
     private final MediaRepository mediaRepo;
     private final AccountRepository accountRepo;
+    private final ProjectMediaRepository projectMediaRepository;
+    private final ThumbnailService thumbnailService;
     private TransactionTemplate txReqNew;
 
     public ClipWorkFlow(ClipRepository clipRepo,
@@ -43,7 +46,7 @@ public class ClipWorkFlow {
                         StorageService storage,
                         ClipRenderEngine renderEngine,
                         AssetRepository assetRepo,
-                        SubtitleService subtitles, MediaRepository mediaRepo, AccountRepository accountRepo, TransactionTemplate txReqNew) {
+                        SubtitleService subtitles, MediaRepository mediaRepo, AccountRepository accountRepo, ProjectMediaRepository projectMediaRepository, ThumbnailService thumbnailService, TransactionTemplate txReqNew) {
         this.clipRepo = clipRepo;
         this.transcriptRepo = transcriptRepo;
         this.storage = storage;
@@ -52,6 +55,8 @@ public class ClipWorkFlow {
         this.subtitles = subtitles;
         this.mediaRepo = mediaRepo;
         this.accountRepo = accountRepo;
+        this.projectMediaRepository = projectMediaRepository;
+        this.thumbnailService = thumbnailService;
         this.txReqNew = txReqNew;
     }
 
@@ -85,6 +90,8 @@ public class ClipWorkFlow {
                 thumb.setRelatedClip(clipRef);
                 thumb.setRelatedMedia(mediaRef);
                 assetRepo.save(thumb);
+                projectMediaRepository.findByMedia(mediaRef)
+                        .forEach(link -> thumbnailService.applyFallbackIfEligible(link.getProject(), res.thumbKey()));
             }
 
             if (subs != null) {

--- a/src/main/java/com/example/clipbot_backend/service/thumbnail/ThumbnailService.java
+++ b/src/main/java/com/example/clipbot_backend/service/thumbnail/ThumbnailService.java
@@ -1,0 +1,63 @@
+package com.example.clipbot_backend.service.thumbnail;
+
+import com.example.clipbot_backend.model.Project;
+import com.example.clipbot_backend.repository.ProjectRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages project thumbnails, allowing uploads to defer thumbnail assignment until the first render completes.
+ */
+@Service
+public class ThumbnailService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThumbnailService.class);
+    private final ProjectRepository projectRepository;
+    private final Set<UUID> pendingFallbacks = ConcurrentHashMap.newKeySet();
+
+    public ThumbnailService(ProjectRepository projectRepository) {
+        this.projectRepository = projectRepository;
+    }
+
+    /**
+     * Registers a project for deferred thumbnail assignment when the first clip render finishes.
+     *
+     * @param projectId project identifier to mark.
+     */
+    public void registerFirstRenderFallback(UUID projectId) {
+        if (projectId == null) {
+            return;
+        }
+        pendingFallbacks.add(projectId);
+        LOGGER.info("ThumbnailService fallback registered projectId={}", projectId);
+    }
+
+    /**
+     * Applies a thumbnail to the project if it is awaiting a fallback and currently has no thumbnail.
+     *
+     * @param project      project entity to mutate when needed.
+     * @param thumbnailUrl thumbnail URL or object key produced by the render flow.
+     */
+    @Transactional
+    public void applyFallbackIfEligible(Project project, String thumbnailUrl) {
+        if (project == null || thumbnailUrl == null || thumbnailUrl.isBlank()) {
+            return;
+        }
+        if (!pendingFallbacks.contains(project.getId())) {
+            return;
+        }
+        if (project.getThumbnailUrl() != null && !project.getThumbnailUrl().isBlank()) {
+            pendingFallbacks.remove(project.getId());
+            return;
+        }
+        project.setThumbnailUrl(thumbnailUrl);
+        projectRepository.save(project);
+        pendingFallbacks.remove(project.getId());
+        LOGGER.info("ThumbnailService fallback applied projectId={} thumbnail={}", project.getId(), thumbnailUrl);
+    }
+}

--- a/src/main/java/com/example/clipbot_backend/util/ThumbnailSource.java
+++ b/src/main/java/com/example/clipbot_backend/util/ThumbnailSource.java
@@ -6,5 +6,6 @@ package com.example.clipbot_backend.util;
 public enum ThumbnailSource {
     YOUTUBE,
     CLIP,
+    DEFERRED,
     NONE
 }

--- a/src/main/resources/db/migration/V29__add_started_at_to_orchestration.sql
+++ b/src/main/resources/db/migration/V29__add_started_at_to_orchestration.sql
@@ -1,0 +1,3 @@
+-- Add started_at to align one_click_orchestration table with entity
+ALTER TABLE one_click_orchestration
+    ADD COLUMN IF NOT EXISTS started_at TIMESTAMPTZ;


### PR DESCRIPTION
## Summary
- add optional projectId support and include it in idempotent one-click fingerprints
- improve orchestration to reuse projects by ID, apply upload-aware defaults, and register deferred thumbnails
- surface thumbnail fallback application after renders with a dedicated service

## Testing
- `mvn test` *(fails: POM references itself)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692985dfdf988331901ee69e9898c4d1)