### PR TITLE
Fix usage counter increments for renders

### DIFF
--- a/src/main/java/com/example/clipbot_backend/service/UsageService.java
+++ b/src/main/java/com/example/clipbot_backend/service/UsageService.java
@@ -52,8 +52,9 @@ public class UsageService {
         UsageCounters counters = usageCountersRepository.findByAccountAndDateKey(account, today)
                 .orElseGet(() -> new UsageCounters(account, today, monthKey));
         counters.setRendersToday(counters.getRendersToday() + 1);
+        counters.setRendersMonth(counters.getRendersMonth() + 1);
         usageCountersRepository.save(counters);
-        LOGGER.info("UsageService increment account={} day={} month={}", account.getId(), counters.getRendersToday(), counters.getRendersMonth());
+        LOGGER.info("UsageService increment account={} rendersToday={} rendersMonth={}", account.getId(), counters.getRendersToday(), counters.getRendersMonth());
     }
 
     /**

--- a/src/test/java/com/example/clipbot_backend/service/UsageServiceTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/UsageServiceTest.java
@@ -1,0 +1,67 @@
+package com.example.clipbot_backend.service;
+
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.UsageCounters;
+import com.example.clipbot_backend.repository.UsageCountersRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * Unit tests for {@link UsageService} to ensure counters increment correctly.
+ */
+class UsageServiceTest {
+    private UsageCountersRepository usageRepo;
+    private UsageService usageService;
+
+    @BeforeEach
+    void setup() {
+        usageRepo = Mockito.mock(UsageCountersRepository.class);
+        usageService = new UsageService(usageRepo);
+    }
+
+    @Test
+    void incrementCreatesNewCountersAndUpdatesDayAndMonth() {
+        Account account = new Account("ext", "User");
+        Mockito.when(usageRepo.findByAccountAndDateKey(any(), any())).thenReturn(Optional.empty());
+        Mockito.when(usageRepo.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        usageService.incrementRenders(account);
+
+        ArgumentCaptor<UsageCounters> captor = ArgumentCaptor.forClass(UsageCounters.class);
+        Mockito.verify(usageRepo).save(captor.capture());
+        UsageCounters saved = captor.getValue();
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        assertThat(saved.getDateKey()).isEqualTo(today);
+        assertThat(saved.getMonthKey()).isEqualTo(today.withDayOfMonth(1));
+        assertThat(saved.getRendersToday()).isEqualTo(1);
+        assertThat(saved.getRendersMonth()).isEqualTo(1);
+    }
+
+    @Test
+    void incrementUpdatesExistingCounters() {
+        Account account = new Account("ext", "User");
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        UsageCounters existing = new UsageCounters(account, today, today.withDayOfMonth(1));
+        existing.setRendersToday(2);
+        existing.setRendersMonth(5);
+        Mockito.when(usageRepo.findByAccountAndDateKey(any(), any())).thenReturn(Optional.of(existing));
+        Mockito.when(usageRepo.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        usageService.incrementRenders(account);
+
+        ArgumentCaptor<UsageCounters> captor = ArgumentCaptor.forClass(UsageCounters.class);
+        Mockito.verify(usageRepo).save(captor.capture());
+        UsageCounters saved = captor.getValue();
+        assertThat(saved.getRendersToday()).isEqualTo(3);
+        assertThat(saved.getRendersMonth()).isEqualTo(6);
+    }
+}


### PR DESCRIPTION
## Summary
- increment both daily and monthly render counters in UsageService
- clarify UsageService increment logging labels to show renders explicitly
- add unit tests covering usage counter increments for new and existing records

## Testing
- mvn -q -DskipITs test *(fails: pom references itself, cannot build project)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372ce91fc08331853631aee6756172)