### PR TITLE
Add project deletion endpoint

### DIFF
--- a/src/main/java/com/example/clipbot_backend/controller/ClipController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/ClipController.java
@@ -119,6 +119,20 @@ public class ClipController {
         ensureOwnedBy(clip, ownerExternalSubject);
         clipService.setStatus(id, status);
     }
+
+    /**
+     * Verwijdert een clip en alle gekoppelde assets.
+     *
+     * @param id clip-identificatie die moet worden verwijderd.
+     * @param ownerExternalSubject eigenaar die moet overeenkomen (admin mag overslaan).
+     */
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id, @RequestParam String ownerExternalSubject) {
+        var clip = clipService.getWithMedia(id);
+        ensureOwnedBy(clip, ownerExternalSubject);
+        clipService.deleteClip(clip);
+    }
     private void ensureOwnedBy(Clip clip, String sub) {
         if (isAdmin(sub)) return; // admin bypass
         var owner = clip.getMedia().getOwner().getExternalSubject();

--- a/src/main/java/com/example/clipbot_backend/controller/ProjectController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/ProjectController.java
@@ -77,13 +77,14 @@ public class ProjectController {
 
     /**
      * Verwijdert een project en de gelinkte project-media rijen.
-     * Clips blijven bestaan voor hergebruik bij andere projecten of workflows.
+     * Clips die exclusief door het project gebruikt worden gaan mee weg; gedeelde clips blijven.
      *
      * @param projectId te verwijderen project-id.
      * @param ownerId optioneel directe owner-id (fallback voor oudere clients).
      * @param ownerExternalSubject optionele externe subjectreferentie om de owner te bepalen.
      *
      * Side-effects:
+     * - Verwijdert clip-assets en clips voor media die alleen aan dit project hangen.
      * - Verwijdert project-media links en het project zelf.
      *
      * Voorbeeld: DELETE /v1/projects/{projectId}?ownerExternalSubject=auth0|user-123

--- a/src/main/java/com/example/clipbot_backend/controller/ProjectController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/ProjectController.java
@@ -75,6 +75,28 @@ public class ProjectController {
         return ProjectResponse.from(project);
     }
 
+    /**
+     * Verwijdert een project en alle clips die gekoppeld zijn via de projectmedia.
+     *
+     * @param projectId te verwijderen project-id.
+     * @param ownerId optioneel directe owner-id (fallback voor oudere clients).
+     * @param ownerExternalSubject optionele externe subjectreferentie om de owner te bepalen.
+     *
+     * Side-effects:
+     * - Deletet clip-assets en clips voor alle gelinkte media.
+     * - Verwijdert project-media links en het project zelf.
+     *
+     * Voorbeeld: DELETE /v1/projects/{projectId}?ownerExternalSubject=auth0|user-123
+     */
+    @DeleteMapping("/{projectId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteProject(@PathVariable UUID projectId,
+                              @RequestParam(required = false) UUID ownerId,
+                              @RequestParam(required = false) String ownerExternalSubject) {
+        UUID resolvedOwnerId = resolveOwnerParam(ownerId, ownerExternalSubject);
+        projectService.deleteProject(projectId, resolvedOwnerId);
+    }
+
     @PostMapping("/{projectId}/media")
     @ResponseStatus(HttpStatus.CREATED)
     public ProjectMediaLinkResponse linkMedia(@PathVariable UUID projectId, @RequestBody LinkReq req) {

--- a/src/main/java/com/example/clipbot_backend/controller/ProjectController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/ProjectController.java
@@ -76,14 +76,14 @@ public class ProjectController {
     }
 
     /**
-     * Verwijdert een project en alle clips die gekoppeld zijn via de projectmedia.
+     * Verwijdert een project en de gelinkte project-media rijen.
+     * Clips blijven bestaan voor hergebruik bij andere projecten of workflows.
      *
      * @param projectId te verwijderen project-id.
      * @param ownerId optioneel directe owner-id (fallback voor oudere clients).
      * @param ownerExternalSubject optionele externe subjectreferentie om de owner te bepalen.
      *
      * Side-effects:
-     * - Deletet clip-assets en clips voor alle gelinkte media.
      * - Verwijdert project-media links en het project zelf.
      *
      * Voorbeeld: DELETE /v1/projects/{projectId}?ownerExternalSubject=auth0|user-123

--- a/src/main/java/com/example/clipbot_backend/repository/AssetRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/AssetRepository.java
@@ -8,7 +8,9 @@ import com.example.clipbot_backend.util.AssetKind;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -21,5 +23,8 @@ public interface AssetRepository extends JpaRepository<Asset, UUID> {
     Optional<Asset> findTopByRelatedMediaAndKindOrderByCreatedAtDesc(Media media, AssetKind kind);
     Page<Asset> findByRelatedClipAndKindOrderByCreatedAtDesc(Clip clip, AssetKind kind, Pageable pageable);
     Page<Asset> findByRelatedMediaAndKindOrderByCreatedAtDesc(Media media, AssetKind kind, Pageable pageable);
+
+    @Transactional
+    void deleteByRelatedClipIn(Collection<Clip> clips);
 
 }

--- a/src/main/java/com/example/clipbot_backend/repository/ClipRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/ClipRepository.java
@@ -75,4 +75,12 @@ public interface ClipRepository extends JpaRepository<Clip, UUID> {
      */
     Optional<Clip> findByMediaIdAndStartMsAndEndMsAndProfileHash(UUID mediaId, long startMs, long endMs, String profileHash);
 
+    /**
+     * Returns all clips associated with any of the provided media records.
+     *
+     * @param media list of media identifiers to match.
+     * @return list of clips linked to the supplied media set.
+     */
+    List<Clip> findByMediaIn(Collection<Media> media);
+
 }

--- a/src/main/java/com/example/clipbot_backend/repository/ProjectMediaRepository.java
+++ b/src/main/java/com/example/clipbot_backend/repository/ProjectMediaRepository.java
@@ -12,8 +12,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface ProjectMediaRepository extends JpaRepository<ProjectMediaLink, ProjectMediaId> {
     boolean existsByProjectAndMedia(Project project, Media media);
@@ -47,5 +49,18 @@ public interface ProjectMediaRepository extends JpaRepository<ProjectMediaLink, 
 
     @Query("select pml from ProjectMediaLink pml where pml.project = :project order by pml.createdAt desc")
     Page<ProjectMediaLink> findByProjectOrderByCreatedAtDesc(@Param("project") Project project, Pageable pageable);
+
+    @Query("""
+           select pml.media.id as mediaId, count(pml) as linkCount
+           from ProjectMediaLink pml
+           where pml.media in :media
+           group by pml.media.id
+           """)
+    List<MediaLinkCount> countByMediaIn(@Param("media") Collection<Media> media);
+
+    interface MediaLinkCount {
+        UUID getMediaId();
+        long getLinkCount();
+    }
 
 }

--- a/src/main/java/com/example/clipbot_backend/service/ClipService.java
+++ b/src/main/java/com/example/clipbot_backend/service/ClipService.java
@@ -5,6 +5,7 @@ import com.example.clipbot_backend.dto.RenderSpec;
 import com.example.clipbot_backend.model.Clip;
 
 import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.repository.AssetRepository;
 import com.example.clipbot_backend.repository.ClipRepository;
 import com.example.clipbot_backend.repository.JobRepository;
 import com.example.clipbot_backend.repository.MediaRepository;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -35,14 +37,22 @@ public class ClipService {
     private final JobRepository jobRepo;
     private final EntitlementService entitlementService;
     private final RenderProfileResolver renderProfileResolver;
+    private final AssetRepository assetRepository;
 
-    public ClipService(ClipRepository clipRepo, MediaRepository mediaRepo, SegmentRepository segmentRepo, JobRepository jobRepo, EntitlementService entitlementService, RenderProfileResolver renderProfileResolver) {
+    public ClipService(ClipRepository clipRepo,
+                       MediaRepository mediaRepo,
+                       SegmentRepository segmentRepo,
+                       JobRepository jobRepo,
+                       EntitlementService entitlementService,
+                       RenderProfileResolver renderProfileResolver,
+                       AssetRepository assetRepository) {
         this.clipRepo = clipRepo;
         this.mediaRepo = mediaRepo;
         this.segmentRepo = segmentRepo;
         this.jobRepo = jobRepo;
         this.entitlementService = entitlementService;
         this.renderProfileResolver = renderProfileResolver;
+        this.assetRepository = assetRepository;
     }
 
     @Transactional
@@ -97,6 +107,19 @@ public class ClipService {
     public Clip get(UUID clipId) {
         return clipRepo.findById(clipId).orElseThrow(() -> new ResponseStatusException(
                 HttpStatus.NOT_FOUND, "Clip not found: " + clipId));
+    }
+
+    /**
+     * Haalt een clip op inclusief media en owner zodat ownership-checks buiten een transactie kunnen gebeuren.
+     *
+     * @param clipId clip-identificatie.
+     * @return clip met eagerly geladen media en owner.
+     * @throws ResponseStatusException wanneer de clip niet bestaat.
+     */
+    @Transactional(readOnly = true)
+    public Clip getWithMedia(UUID clipId) {
+        return clipRepo.findByIdWithMedia(clipId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Clip not found: " + clipId));
     }
     @Transactional
     public UUID enqueueRender(JobService jobs, UUID clipId) {
@@ -168,6 +191,19 @@ public class ClipService {
     public Clip save(Clip clip){
         return clipRepo.save(clip);
 
+    }
+
+    /**
+     * Verwijdert een clip en alle gekoppelde assets.
+     *
+     * @param clip clip-entiteit die verwijderd moet worden, inclusief geladen media/owner.
+     */
+    @Transactional
+    public void deleteClip(Clip clip) {
+        Objects.requireNonNull(clip, "clip");
+
+        assetRepository.deleteByRelatedClipIn(List.of(clip));
+        clipRepo.delete(clip);
     }
 
 

--- a/src/main/java/com/example/clipbot_backend/service/ClipService.java
+++ b/src/main/java/com/example/clipbot_backend/service/ClipService.java
@@ -16,6 +16,8 @@ import com.example.clipbot_backend.util.ClipStatus;
 import com.example.clipbot_backend.util.JobType;
 
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -31,6 +33,8 @@ import java.util.UUID;
 
 @Service
 public class ClipService {
+    private static final Logger log = LoggerFactory.getLogger(ClipService.class);
+
     private final ClipRepository clipRepo;
     private final MediaRepository mediaRepo;
     private final SegmentRepository segmentRepo;
@@ -202,8 +206,20 @@ public class ClipService {
     public void deleteClip(Clip clip) {
         Objects.requireNonNull(clip, "clip");
 
+        var media = clip.getMedia();
+        var owner = media != null ? media.getOwner() : null;
+        log.info("START delete clip id={} mediaId={} ownerId={}",
+                clip.getId(),
+                media != null ? media.getId() : null,
+                owner != null ? owner.getId() : null);
+
         assetRepository.deleteByRelatedClipIn(List.of(clip));
         clipRepo.delete(clip);
+
+        log.info("DONE delete clip id={} mediaId={} ownerId={}",
+                clip.getId(),
+                media != null ? media.getId() : null,
+                owner != null ? owner.getId() : null);
     }
 
 

--- a/src/main/java/com/example/clipbot_backend/service/ProjectService.java
+++ b/src/main/java/com/example/clipbot_backend/service/ProjectService.java
@@ -10,6 +10,8 @@ import com.example.clipbot_backend.model.ProjectMediaLink;
 import com.example.clipbot_backend.repository.*;
 import com.example.clipbot_backend.service.AccountService;
 import com.example.clipbot_backend.util.ClipStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -24,6 +26,8 @@ import java.util.UUID;
 
 @Service
 public class ProjectService {
+    private static final Logger log = LoggerFactory.getLogger(ProjectService.class);
+
     private final ProjectRepository projectRepository;
     private final ProjectMediaRepository projectMediaRepository;
     private final AccountService accountService;
@@ -246,9 +250,11 @@ public class ProjectService {
         var project = ensureProjectOwnedBy(projectId, owner);
 
         var mediaList = projectMediaRepository.findMediaByProject(project);
+        log.info("START delete project id={} ownerId={} mediaCount={}", project.getId(), owner.getId(), mediaList.size());
         if (!mediaList.isEmpty()) {
             var clips = clipRepository.findByMediaIn(mediaList);
             if (!clips.isEmpty()) {
+                log.info("Deleting clips for project id={} clipCount={}", project.getId(), clips.size());
                 assetRepository.deleteByRelatedClipIn(clips);
                 clipRepository.deleteAll(clips);
             }
@@ -260,6 +266,8 @@ public class ProjectService {
         }
 
         projectRepository.delete(project);
+
+        log.info("DONE delete project id={} ownerId={} mediaCount={}", project.getId(), owner.getId(), mediaList.size());
     }
 
 


### PR DESCRIPTION
## Summary
- add DELETE /v1/projects/{projectId} endpoint to remove a project via owner bridging
- clean up clip assets, clips, project-media links, and project records in ProjectService
- extend repositories with helpers for bulk clip retrieval and asset deletion

## Testing
- `./mvnw -q -DskipTests compile` *(fails: cannot download Maven distribution in the environment)*

## Rationale
Adds the missing endpoint so a project and its associated clips can be removed in one call, including dependent assets and links.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938039c3a4c8331839ab29dadff853b)