### PR TITLE
Document podcast flag and add speaker mode tests

### DIFF
--- a/src/main/java/com/example/clipbot_backend/controller/MediaController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/MediaController.java
@@ -46,7 +46,14 @@ public class MediaController {
         SpeakerMode speakerMode = request.podcastOrInterview() ? SpeakerMode.MULTI : SpeakerMode.SINGLE;
 
         UUID mediaId = mediaService.createMediaFromUrl(
-                request.ownerId(), normalizedUrl, platform, source, durationMs, request.objectKeyOverride(), speakerMode
+                request.ownerId(),
+                request.ownerExternalSubject(),
+                normalizedUrl,
+                platform,
+                source,
+                durationMs,
+                request.objectKeyOverride(),
+                speakerMode
         );
         Media media = mediaService.get(mediaId);
         // Service zet DOWNLOADING; dat moeten we zo teruggeven:

--- a/src/main/java/com/example/clipbot_backend/controller/MediaController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/MediaController.java
@@ -10,6 +10,7 @@ import com.example.clipbot_backend.service.metadata.MetadataResult;
 import com.example.clipbot_backend.service.metadata.MetadataService;
 import com.example.clipbot_backend.util.MediaPlatform;
 import com.example.clipbot_backend.util.MediaStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -42,9 +43,10 @@ public class MediaController {
         final String normalizedUrl = (md != null ? md.url() : metadataService.normalizeUrl(request.url()));
         final MediaPlatform platform = (md != null ? md.platform() : metadataService.detectPlatform(request.url()));
         final Long durationMs = (md != null && md.durationSec() != null) ? safeToMillis(md.durationSec()) : null;
+        SpeakerMode speakerMode = request.podcastOrInterview() ? SpeakerMode.MULTI : SpeakerMode.SINGLE;
 
         UUID mediaId = mediaService.createMediaFromUrl(
-                request.ownerId(), normalizedUrl, platform, source, durationMs, request.objectKeyOverride()
+                request.ownerId(), normalizedUrl, platform, source, durationMs, request.objectKeyOverride(), speakerMode
         );
         Media media = mediaService.get(mediaId);
         // Service zet DOWNLOADING; dat moeten we zo teruggeven:

--- a/src/main/java/com/example/clipbot_backend/controller/UploadController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/UploadController.java
@@ -31,8 +31,9 @@ public class UploadController {
             @RequestParam("owner") String ownerExternalSubject,
             @RequestParam(value = "objectKey", required = false) String objectKey,
             @RequestPart("file") MultipartFile file,
-            @RequestParam(value = "source", required = false, defaultValue = "upload") String source) throws Exception {
-        return uploadService.uploadLocal(ownerExternalSubject, objectKey, file, source);
+            @RequestParam(value = "source", required = false, defaultValue = "upload") String source,
+            @RequestParam(value = "podcastOrInterview", required = false, defaultValue = "false") boolean podcastOrInterview) throws Exception {
+        return uploadService.uploadLocal(ownerExternalSubject, objectKey, file, source, podcastOrInterview);
     }
 
 

--- a/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/orchestrate/OneClickRequest.java
@@ -12,6 +12,10 @@ public record OneClickRequest(
         String url,
         UUID mediaId,
         String title,
+        /**
+         * Hint from the frontend that the content is a podcast or interview and should use multi-speaker diarization.
+         */
+        Boolean podcastOrInterview,
         Options opts,
         @NotBlank String idempotencyKey,
         UUID projectId

--- a/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
@@ -4,8 +4,6 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-import java.util.UUID;
-
 /**
  * Ingestverzoek voor een mediabestand vanaf een externe URL.
  * <p>
@@ -13,11 +11,12 @@ import java.util.UUID;
  * gesprek met meerdere sprekers gaat; de backend gebruikt dit om de multi-speaker
  * diarization route (GPT-4o) te kiezen.
  * <p>
- * Voor eigenaarschap kan een interne {@code ownerId} of een externe {@code ownerExternalSubject}
- * worden meegegeven; exact één van beide is verplicht.
+ * Voor eigenaarschap kan een interne {@code ownerId} (UUID) of een externe {@code ownerExternalSubject}
+ * worden meegegeven; exact één van beide is verplicht. Als {@code ownerId} geen geldige UUID is, wordt
+ * deze als external subject behandeld voor backwards compatibility.
  */
 public record MediaFromUrlRequest(
-        UUID ownerId,
+        String ownerId,
         String ownerExternalSubject,
         @NotBlank @Size(max = 2048) String url,
         String source,
@@ -26,10 +25,10 @@ public record MediaFromUrlRequest(
 ) {
     @AssertTrue(message = "Either ownerId or ownerExternalSubject is required")
     public boolean hasOwner() {
-        return ownerId != null || (ownerExternalSubject != null && !ownerExternalSubject.isBlank());
+        return (ownerId != null && !ownerId.isBlank()) || (ownerExternalSubject != null && !ownerExternalSubject.isBlank());
     }
     @AssertTrue(message = "Provide either ownerId or ownerExternalSubject, not both")
     public boolean notBothOwners() {
-        return !(ownerId != null && ownerExternalSubject != null && !ownerExternalSubject.isBlank());
+        return !((ownerId != null && !ownerId.isBlank()) && (ownerExternalSubject != null && !ownerExternalSubject.isBlank()));
     }
 }

--- a/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
@@ -6,10 +6,18 @@ import jakarta.validation.constraints.Size;
 
 import java.util.UUID;
 
+/**
+ * Ingestverzoek voor een mediabestand vanaf een externe URL.
+ * <p>
+ * De boolean {@code podcastOrInterview} wordt door de frontend gezet wanneer het om een
+ * gesprek met meerdere sprekers gaat; de backend gebruikt dit om de multi-speaker
+ * diarization route (GPT-4o) te kiezen.
+ */
 public record MediaFromUrlRequest(
         @NotNull UUID ownerId,
         @NotBlank @Size(max = 2048) String url,
         String source,
-        String objectKeyOverride
+        String objectKeyOverride,
+        boolean podcastOrInterview
 ) {
 }

--- a/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
@@ -1,7 +1,7 @@
 package com.example.clipbot_backend.dto.web;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.util.UUID;
@@ -12,12 +12,24 @@ import java.util.UUID;
  * De boolean {@code podcastOrInterview} wordt door de frontend gezet wanneer het om een
  * gesprek met meerdere sprekers gaat; de backend gebruikt dit om de multi-speaker
  * diarization route (GPT-4o) te kiezen.
+ * <p>
+ * Voor eigenaarschap kan een interne {@code ownerId} of een externe {@code ownerExternalSubject}
+ * worden meegegeven; exact één van beide is verplicht.
  */
 public record MediaFromUrlRequest(
-        @NotNull UUID ownerId,
+        UUID ownerId,
+        String ownerExternalSubject,
         @NotBlank @Size(max = 2048) String url,
         String source,
         String objectKeyOverride,
         boolean podcastOrInterview
 ) {
+    @AssertTrue(message = "Either ownerId or ownerExternalSubject is required")
+    public boolean hasOwner() {
+        return ownerId != null || (ownerExternalSubject != null && !ownerExternalSubject.isBlank());
+    }
+    @AssertTrue(message = "Provide either ownerId or ownerExternalSubject, not both")
+    public boolean notBothOwners() {
+        return !(ownerId != null && ownerExternalSubject != null && !ownerExternalSubject.isBlank());
+    }
 }

--- a/src/main/java/com/example/clipbot_backend/model/Media.java
+++ b/src/main/java/com/example/clipbot_backend/model/Media.java
@@ -14,8 +14,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.example.clipbot_backend.util.SpeakerMode.*;
-
 @Entity
 public class Media {
     @Id
@@ -56,7 +54,7 @@ public class Media {
     private Integer speakerCountDetected;
 
     @Enumerated(EnumType.STRING)
-    private SpeakerMode speakerMode = AUTO;
+    private SpeakerMode speakerMode = SINGLE;
 
     public Media(UUID id, Account owner, String objectKey, Long durationMs,String source, Instant createdAt) {
         this.id = id;
@@ -163,12 +161,8 @@ public class Media {
 
     @Transient
     public boolean isMultiSpeakerEffective() {
-        SpeakerMode mode = this.speakerMode != null ? this.speakerMode : SpeakerMode.AUTO;
-        return switch (mode) {
-            case MULTI  -> true;                                  // Interview/Podcast
-            case SINGLE -> false;                                 // Monologue
-            case AUTO   -> (speakerCountDetected != null && speakerCountDetected > 1);
-        };
+        SpeakerMode mode = this.speakerMode != null ? this.speakerMode : SpeakerMode.SINGLE;
+        return SpeakerMode.MULTI.equals(mode);
     }
 }
 

--- a/src/main/java/com/example/clipbot_backend/model/Media.java
+++ b/src/main/java/com/example/clipbot_backend/model/Media.java
@@ -162,6 +162,9 @@ public class Media {
     @Transient
     public boolean isMultiSpeakerEffective() {
         SpeakerMode mode = this.speakerMode != null ? this.speakerMode : SpeakerMode.SINGLE;
+        if (SpeakerMode.AUTO.equals(mode)) {
+            return false;
+        }
         return SpeakerMode.MULTI.equals(mode);
     }
 }

--- a/src/main/java/com/example/clipbot_backend/model/Media.java
+++ b/src/main/java/com/example/clipbot_backend/model/Media.java
@@ -54,7 +54,7 @@ public class Media {
     private Integer speakerCountDetected;
 
     @Enumerated(EnumType.STRING)
-    private SpeakerMode speakerMode = SINGLE;
+    private SpeakerMode speakerMode = SpeakerMode.SINGLE;
 
     public Media(UUID id, Account owner, String objectKey, Long durationMs,String source, Instant createdAt) {
         this.id = id;

--- a/src/main/java/com/example/clipbot_backend/service/DetectionService.java
+++ b/src/main/java/com/example/clipbot_backend/service/DetectionService.java
@@ -52,6 +52,10 @@ public class DetectionService {
                               Integer topN,
                               Boolean enqueueRender) {
         Media media = mediaRepo.findById(mediaId).orElseThrow();
+        if (!transcriptRepo.existsByMediaId(mediaId)) {
+            return jobService.enqueue(media.getId(), JobType.TRANSCRIBE, Map.of());
+        }
+
         Map<String, Object> payload = new LinkedHashMap<>();
         if (lang != null) payload.put("lang", lang);
         if (provider != null) payload.put("provider", provider);

--- a/src/main/java/com/example/clipbot_backend/service/Interfaces/MediaService.java
+++ b/src/main/java/com/example/clipbot_backend/service/Interfaces/MediaService.java
@@ -15,5 +15,12 @@ public interface MediaService {
     Media get(UUID mediaId);
     void setStatus(UUID mediaId, MediaStatus status);
     void setDuration(UUID mediaId, long durationMs);
-    UUID createMediaFromUrl(UUID ownerId, String externalUrl, MediaPlatform platform, String source, Long durationMs, SpeakerMode speakerMode);
+    UUID createMediaFromUrl(UUID ownerId,
+                            String ownerExternalSubject,
+                            String externalUrl,
+                            MediaPlatform platform,
+                            String source,
+                            Long durationMs,
+                            String objectKeyOverride,
+                            SpeakerMode speakerMode);
 }

--- a/src/main/java/com/example/clipbot_backend/service/Interfaces/MediaService.java
+++ b/src/main/java/com/example/clipbot_backend/service/Interfaces/MediaService.java
@@ -3,6 +3,7 @@ package com.example.clipbot_backend.service.Interfaces;
 import com.example.clipbot_backend.model.Media;
 import com.example.clipbot_backend.util.MediaPlatform;
 import com.example.clipbot_backend.util.MediaStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -14,5 +15,5 @@ public interface MediaService {
     Media get(UUID mediaId);
     void setStatus(UUID mediaId, MediaStatus status);
     void setDuration(UUID mediaId, long durationMs);
-    UUID createMediaFromUrl(UUID ownerId, String externalUrl, MediaPlatform platform, String source, Long durationMs);
+    UUID createMediaFromUrl(UUID ownerId, String externalUrl, MediaPlatform platform, String source, Long durationMs, SpeakerMode speakerMode);
 }

--- a/src/main/java/com/example/clipbot_backend/service/MediaService.java
+++ b/src/main/java/com/example/clipbot_backend/service/MediaService.java
@@ -6,6 +6,7 @@ import com.example.clipbot_backend.dto.media.CreateFromUrlResponse;
 import com.example.clipbot_backend.repository.MediaRepository;
 import com.example.clipbot_backend.util.MediaPlatform;
 import com.example.clipbot_backend.util.MediaStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
 import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -79,7 +80,8 @@ public class MediaService  {
             MediaPlatform platform,
             String source,
             Long durationMs,
-            String objectKeyOverride // ← gebruik dit als caller er eentje meegeeft
+            String objectKeyOverride, // ← gebruik dit als caller er eentje meegeeft
+            SpeakerMode speakerMode
     ) {
         var owner = accountService.getByIdOrThrow(ownerId);
 
@@ -99,6 +101,7 @@ public class MediaService  {
         media.setStatus(MediaStatus.DOWNLOADING);
         // Status die in je CHECK-constraint toegestaan is
         if (durationMs != null && durationMs > 0) media.setDurationMs(durationMs);
+        media.setSpeakerMode(speakerMode != null ? speakerMode : SpeakerMode.SINGLE);
 
         // Kies objectKey:
         // - Als caller er al een gaf: neem die.
@@ -113,7 +116,7 @@ public class MediaService  {
     }
 
     public CreateFromUrlResponse createFromUrl(UUID ownerId, String url, String source) {
-        UUID mediaId = createMediaFromUrl(ownerId, url, MediaPlatform.OTHER, source, null, null);
+        UUID mediaId = createMediaFromUrl(ownerId, url, MediaPlatform.OTHER, source, null, null, null);
         return new CreateFromUrlResponse(mediaId);
     }
 

--- a/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
+++ b/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
@@ -222,6 +222,7 @@ public class OneClickOrchestrator {
                         platform,
                         "ingest",
                         durationMs,
+                        null,
                         null)
         );
         return created.mediaId();

--- a/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
+++ b/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
@@ -18,6 +18,7 @@ import com.example.clipbot_backend.service.metadata.MetadataService;
 import com.example.clipbot_backend.service.thumbnail.ThumbnailService;
 import com.example.clipbot_backend.util.MediaPlatform;
 import com.example.clipbot_backend.util.OrchestrationStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
 import com.example.clipbot_backend.util.ThumbnailSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -216,6 +217,7 @@ public class OneClickOrchestrator {
 
         MediaPlatform platform = metadata != null ? metadata.platform() : MediaPlatform.OTHER;
         Long durationMs = metadata != null && metadata.durationSec() != null ? metadata.durationSec() * 1000 : null;
+        boolean podcastOrInterview = request.podcastOrInterview() != null && request.podcastOrInterview();
         CreateFromUrlResponse created = new CreateFromUrlResponse(
                 mediaService.createMediaFromUrl(
                         project.getOwner().getId(),
@@ -225,7 +227,7 @@ public class OneClickOrchestrator {
                         "ingest",
                         durationMs,
                         null,
-                        null)
+                        podcastOrInterview ? SpeakerMode.MULTI : SpeakerMode.SINGLE)
         );
         return created.mediaId();
     }
@@ -358,6 +360,7 @@ public class OneClickOrchestrator {
         builder.append("|mediaId:").append(request.mediaId() == null ? "" : request.mediaId());
         builder.append("|projectId:").append(request.projectId() == null ? "" : request.projectId());
         builder.append("|title:").append(request.title() == null ? "" : request.title().trim());
+        builder.append("|podcastOrInterview:").append(request.podcastOrInterview() == null ? "" : request.podcastOrInterview());
         OneClickRequest.Options opts = request.opts();
         if (opts != null) {
             builder.append("|lang:").append(opts.lang() == null ? "" : opts.lang());

--- a/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
+++ b/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
@@ -217,7 +217,9 @@ public class OneClickOrchestrator {
         MediaPlatform platform = metadata != null ? metadata.platform() : MediaPlatform.OTHER;
         Long durationMs = metadata != null && metadata.durationSec() != null ? metadata.durationSec() * 1000 : null;
         CreateFromUrlResponse created = new CreateFromUrlResponse(
-                mediaService.createMediaFromUrl(project.getOwner().getId(),
+                mediaService.createMediaFromUrl(
+                        project.getOwner().getId(),
+                        project.getOwner().getExternalSubject(),
                         metadata != null ? metadata.url() : request.url(),
                         platform,
                         "ingest",

--- a/src/main/java/com/example/clipbot_backend/service/UploadService.java
+++ b/src/main/java/com/example/clipbot_backend/service/UploadService.java
@@ -16,6 +16,7 @@ import com.example.clipbot_backend.util.AssetKind;
 import com.example.clipbot_backend.util.JobStatus;
 import com.example.clipbot_backend.util.JobType;
 import com.example.clipbot_backend.util.MediaStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,7 +64,8 @@ public class UploadService {
     public UploadCompleteResponse uploadLocal(String ownerExternalSubject,
                                               String objectKey,
                                               MultipartFile file,
-                                              String sourceLabel) throws Exception {
+                                              String sourceLabel,
+                                              boolean podcastOrInterview) throws Exception {
         if (file == null || file.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "FILE_EMPTY");
         }
@@ -80,6 +82,7 @@ public class UploadService {
 
         var media = new Media(owner, objectKey);
         media.setSource(sourceLabel == null ? "upload" : sourceLabel.trim().toLowerCase());
+        media.setSpeakerMode(podcastOrInterview ? SpeakerMode.MULTI : SpeakerMode.SINGLE);
         media.setStatus(MediaStatus.REGISTERED);
         mediarepo.saveAndFlush(media);
         Path tmp = null;

--- a/src/main/java/com/example/clipbot_backend/util/SpeakerMode.java
+++ b/src/main/java/com/example/clipbot_backend/util/SpeakerMode.java
@@ -1,5 +1,6 @@
 package com.example.clipbot_backend.util;
 
 public enum SpeakerMode {
-    AUTO, SINGLE, MULTI
+    SINGLE,
+    MULTI
 }

--- a/src/main/java/com/example/clipbot_backend/util/SpeakerMode.java
+++ b/src/main/java/com/example/clipbot_backend/util/SpeakerMode.java
@@ -1,6 +1,7 @@
 package com.example.clipbot_backend.util;
 
 public enum SpeakerMode {
+    AUTO,
     SINGLE,
     MULTI
 }

--- a/src/test/java/com/example/clipbot_backend/controller/MediaControllerTest.java
+++ b/src/test/java/com/example/clipbot_backend/controller/MediaControllerTest.java
@@ -1,0 +1,73 @@
+package com.example.clipbot_backend.controller;
+
+import com.example.clipbot_backend.dto.web.MediaFromUrlRequest;
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.service.MediaService;
+import com.example.clipbot_backend.service.metadata.MetadataService;
+import com.example.clipbot_backend.util.MediaPlatform;
+import com.example.clipbot_backend.util.MediaStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaControllerTest {
+
+    @Mock
+    private MediaService mediaService;
+
+    @Mock
+    private MetadataService metadataService;
+
+    @Test
+    void nonUuidOwnerIdFallsBackToExternalSubject() {
+        MediaController controller = new MediaController(mediaService, metadataService);
+        MediaFromUrlRequest request = new MediaFromUrlRequest(
+                "demo-user-1",
+                null,
+                "https://example.com/audio.mp3",
+                null,
+                null,
+                false
+        );
+
+        when(metadataService.resolve(any(String.class))).thenReturn(null);
+        when(metadataService.normalizeUrl(any(String.class))).thenReturn("https://example.com/audio.mp3");
+        when(metadataService.detectPlatform(any(String.class))).thenReturn(MediaPlatform.OTHER);
+
+        UUID mediaId = UUID.randomUUID();
+        when(mediaService.createMediaFromUrl(any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(mediaId);
+
+        Account owner = new Account("demo-user-1", "demo-user-1");
+        Media media = new Media();
+        media.setId(mediaId);
+        media.setOwner(owner);
+        media.setObjectKey("ext/url/source.m4a");
+        media.setStatus(MediaStatus.DOWNLOADING);
+        when(mediaService.get(mediaId)).thenReturn(media);
+
+        controller.createFromUrl(request);
+
+        ArgumentCaptor<UUID> ownerId = ArgumentCaptor.forClass(UUID.class);
+        ArgumentCaptor<String> externalSubject = ArgumentCaptor.forClass(String.class);
+        verify(mediaService).createMediaFromUrl(
+                ownerId.capture(),
+                externalSubject.capture(),
+                any(), any(), any(), any(), any(), any()
+        );
+
+        assertThat(ownerId.getValue()).isNull();
+        assertThat(externalSubject.getValue()).isEqualTo("demo-user-1");
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/model/MediaTest.java
+++ b/src/test/java/com/example/clipbot_backend/model/MediaTest.java
@@ -1,0 +1,18 @@
+package com.example.clipbot_backend.model;
+
+import com.example.clipbot_backend.util.SpeakerMode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MediaTest {
+
+    @Test
+    void legacyAutoSpeakerModeIsTreatedAsSingle() {
+        Media media = new Media();
+        media.setSpeakerMode(SpeakerMode.AUTO);
+
+        assertThat(media.isMultiSpeakerEffective()).isFalse();
+    }
+}
+

--- a/src/test/java/com/example/clipbot_backend/service/DetectionServiceTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/DetectionServiceTest.java
@@ -1,0 +1,70 @@
+package com.example.clipbot_backend.service;
+
+import com.example.clipbot_backend.engine.Interfaces.DetectionEngine;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.repository.SegmentRepository;
+import com.example.clipbot_backend.repository.TranscriptRepository;
+import com.example.clipbot_backend.service.Interfaces.StorageService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DetectionServiceTest {
+
+    @Mock JobService jobService;
+    @Mock MediaRepository mediaRepo;
+    @Mock TranscriptRepository transcriptRepo;
+    @Mock SegmentRepository segmentRepo;
+    @Mock StorageService storageService;
+    @Mock DetectionEngine detectionEngine;
+
+    @InjectMocks DetectionService detectionService;
+
+    @Test
+    void enqueueDetectFallsBackToTranscribeWhenTranscriptMissing() {
+        UUID mediaId = UUID.randomUUID();
+        Media media = new Media();
+        media.setId(mediaId);
+
+        when(mediaRepo.findById(mediaId)).thenReturn(Optional.of(media));
+        when(transcriptRepo.existsByMediaId(mediaId)).thenReturn(false);
+
+        detectionService.enqueueDetect(mediaId, "en", "provider", null, null, null);
+
+        verify(jobService).enqueue(eq(mediaId), eq(com.example.clipbot_backend.util.JobType.TRANSCRIBE), eq(Map.of()));
+    }
+
+    @Test
+    void enqueueDetectUsesDetectWhenTranscriptExists() {
+        UUID mediaId = UUID.randomUUID();
+        Media media = new Media();
+        media.setId(mediaId);
+
+        when(mediaRepo.findById(mediaId)).thenReturn(Optional.of(media));
+        when(transcriptRepo.existsByMediaId(mediaId)).thenReturn(true);
+
+        detectionService.enqueueDetect(mediaId, "en", "provider", 0.5, 3, true);
+
+        ArgumentCaptor<Map<String, Object>> payload = ArgumentCaptor.forClass(Map.class);
+        verify(jobService).enqueue(eq(mediaId), eq(com.example.clipbot_backend.util.JobType.DETECT), payload.capture());
+        assertThat(payload.getValue()).containsEntry("lang", "en");
+        assertThat(payload.getValue()).containsEntry("provider", "provider");
+        assertThat(payload.getValue()).containsEntry("sceneThreshold", 0.5);
+        assertThat(payload.getValue()).containsEntry("topN", 3);
+        assertThat(payload.getValue()).containsEntry("enqueueRender", true);
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/service/MediaServiceTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/MediaServiceTest.java
@@ -47,8 +47,6 @@ class MediaServiceTest {
                 MediaPlatform.OTHER,
                 "url",
                 1_000L,
-                null,
-                null,
                 null
         );
 
@@ -80,7 +78,6 @@ class MediaServiceTest {
                 MediaPlatform.OTHER,
                 "url",
                 1_000L,
-                null,
                 null,
                 SpeakerMode.MULTI
         );

--- a/src/test/java/com/example/clipbot_backend/service/MediaServiceTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/MediaServiceTest.java
@@ -1,0 +1,91 @@
+package com.example.clipbot_backend.service;
+
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.util.MediaPlatform;
+import com.example.clipbot_backend.util.MediaStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MediaServiceTest {
+
+    @Mock
+    private MediaRepository mediaRepository;
+
+    @Mock
+    private AccountService accountService;
+
+    @Test
+    void createFromUrlDefaultsToSingleSpeakerWhenFlagOmitted() {
+        MediaService service = new MediaService(mediaRepository, accountService);
+        UUID ownerId = UUID.randomUUID();
+        Account owner = new Account("owner", "owner");
+        when(accountService.getByIdOrThrow(ownerId)).thenReturn(owner);
+        when(mediaRepository.save(any(Media.class))).thenAnswer(invocation -> {
+            Media media = invocation.getArgument(0, Media.class);
+            media.setId(UUID.randomUUID());
+            return media;
+        });
+
+        UUID mediaId = service.createMediaFromUrl(
+                ownerId,
+                "https://example.com/audio.mp3",
+                MediaPlatform.OTHER,
+                "url",
+                1_000L,
+                null,
+                null
+        );
+
+        ArgumentCaptor<Media> saved = ArgumentCaptor.forClass(Media.class);
+        verify(mediaRepository).save(saved.capture());
+        Media persisted = saved.getValue();
+
+        assertThat(mediaId).isNotNull();
+        assertThat(persisted.getSpeakerMode()).isEqualTo(SpeakerMode.SINGLE);
+        assertThat(persisted.getStatus()).isEqualTo(MediaStatus.DOWNLOADING);
+    }
+
+    @Test
+    void createFromUrlUsesMultiSpeakerWhenRequested() {
+        MediaService service = new MediaService(mediaRepository, accountService);
+        UUID ownerId = UUID.randomUUID();
+        Account owner = new Account("owner", "owner");
+        when(accountService.getByIdOrThrow(ownerId)).thenReturn(owner);
+        when(mediaRepository.save(any(Media.class))).thenAnswer(invocation -> {
+            Media media = invocation.getArgument(0, Media.class);
+            media.setId(UUID.randomUUID());
+            return media;
+        });
+
+        UUID mediaId = service.createMediaFromUrl(
+                ownerId,
+                "https://example.com/audio.mp3",
+                MediaPlatform.OTHER,
+                "url",
+                1_000L,
+                null,
+                SpeakerMode.MULTI
+        );
+
+        ArgumentCaptor<Media> saved = ArgumentCaptor.forClass(Media.class);
+        verify(mediaRepository).save(saved.capture());
+        Media persisted = saved.getValue();
+
+        assertThat(mediaId).isNotNull();
+        assertThat(persisted.getSpeakerMode()).isEqualTo(SpeakerMode.MULTI);
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
@@ -110,7 +110,7 @@ class OneClickOrchestratorTest {
                 .thenReturn(Optional.empty());
         when(projectService.findByNormalizedUrl(anyString(), anyString())).thenReturn(Optional.empty());
         when(projectService.createProjectBySubject(anyString(), anyString(), any(), any())).thenReturn(project);
-        when(mediaService.createMediaFromUrl(any(), any(), any(), anyString(), any(), any())).thenReturn(mediaId);
+        when(mediaService.createMediaFromUrl(any(), anyString(), anyString(), any(), anyString(), any(), any(), any())).thenReturn(mediaId);
         when(detectionService.enqueueDetect(any(), anyString(), anyString(), any(), any(), any())).thenReturn(jobId);
         when(transcriptRepository.existsByMediaId(mediaId)).thenReturn(true);
         when(segmentRepository.countByMediaId(mediaId)).thenReturn(3L);
@@ -168,7 +168,7 @@ class OneClickOrchestratorTest {
 
         assertThat(response.getMediaId()).isEqualTo(mediaId);
         assertThat(response.isCreatedProject()).isTrue();
-        verify(mediaService, never()).createMediaFromUrl(any(), any(), any(), anyString(), any(), any());
+        verify(mediaService, never()).createMediaFromUrl(any(), anyString(), anyString(), any(), anyString(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -99,6 +100,7 @@ class OneClickOrchestratorTest {
                 "https://youtube.com/watch?v=abc",
                 null,
                 "My import",
+                true,
                 new OneClickRequest.Options("auto", "fasterwhisper", 0.3, 6, true),
                 "idem-1",
                 null
@@ -126,6 +128,7 @@ class OneClickOrchestratorTest {
         assertThat(response.getThumbnailSource()).isEqualTo("YOUTUBE");
 
         verify(projectService).patch(projectId, org.mockito.ArgumentMatchers.any());
+        verify(mediaService).createMediaFromUrl(any(), anyString(), anyString(), any(), anyString(), any(), any(), eq(com.example.clipbot_backend.util.SpeakerMode.MULTI));
     }
 
     @Test
@@ -148,6 +151,7 @@ class OneClickOrchestratorTest {
                 owner.getExternalSubject(),
                 null,
                 mediaId,
+                null,
                 null,
                 new OneClickRequest.Options(null, null, null, null, null),
                 "idem-2",
@@ -192,7 +196,7 @@ class OneClickOrchestratorTest {
             throw new RuntimeException(e);
         }
 
-        OneClickRequest request = new OneClickRequest("demo", "https://example.com", null, null, null, "idem-3", null);
+        OneClickRequest request = new OneClickRequest("demo", "https://example.com", null, null, null, null, "idem-3", null);
 
         when(orchestrationRepository.findByOwnerExternalSubjectAndIdempotencyKey("demo", "idem-3"))
                 .thenReturn(Optional.of(entity));
@@ -205,7 +209,7 @@ class OneClickOrchestratorTest {
 
     @Test
     void orchestrateValidatesExclusiveInputs() {
-        OneClickRequest request = new OneClickRequest("demo", "https://example.com", UUID.randomUUID(), null, null, "idem-4", null);
+        OneClickRequest request = new OneClickRequest("demo", "https://example.com", UUID.randomUUID(), null, null, null, "idem-4", null);
 
         assertThatThrownBy(() -> orchestrator.orchestrate(request))
                 .isInstanceOf(ResponseStatusException.class)
@@ -223,7 +227,7 @@ class OneClickOrchestratorTest {
         when(orchestrationRepository.findByOwnerExternalSubjectAndIdempotencyKey("demo", "idem-5"))
                 .thenReturn(Optional.of(existing));
 
-        OneClickRequest request = new OneClickRequest("demo", "https://example.com/b", null, "Title", null, "idem-5", null);
+        OneClickRequest request = new OneClickRequest("demo", "https://example.com/b", null, "Title", null, null, "idem-5", null);
 
         assertThatThrownBy(() -> orchestrator.orchestrate(request))
                 .isInstanceOf(ResponseStatusException.class)

--- a/src/test/java/com/example/clipbot_backend/service/UploadServiceTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/UploadServiceTest.java
@@ -1,0 +1,130 @@
+package com.example.clipbot_backend.service;
+
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Asset;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.repository.AccountRepository;
+import com.example.clipbot_backend.repository.AssetRepository;
+import com.example.clipbot_backend.repository.JobRepository;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.service.Interfaces.StorageService;
+import com.example.clipbot_backend.util.MediaStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UploadServiceTest {
+
+    @Mock
+    private StorageService storageService;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private MediaRepository mediaRepository;
+
+    @Mock
+    private AssetRepository assetRepository;
+
+    @Mock
+    private JobRepository jobRepository;
+
+    @Mock
+    private JobService jobService;
+
+    @Test
+    void uploadLocalDefaultsToSingleSpeakerWhenFlagFalse() throws Exception {
+        UploadService uploadService = new UploadService(
+                storageService,
+                accountRepository,
+                mediaRepository,
+                assetRepository,
+                jobRepository,
+                jobService
+        );
+
+        Account owner = new Account("owner", "owner");
+        when(accountRepository.findByExternalSubject("owner")).thenReturn(Optional.of(owner));
+        when(mediaRepository.saveAndFlush(any(Media.class))).thenAnswer(invocation -> {
+            Media media = invocation.getArgument(0, Media.class);
+            media.setId(UUID.randomUUID());
+            return media;
+        });
+        when(mediaRepository.save(any(Media.class))).thenAnswer(invocation -> invocation.getArgument(0, Media.class));
+        when(assetRepository.save(any(Asset.class))).thenAnswer(invocation -> {
+            Asset asset = invocation.getArgument(0, Asset.class);
+            asset.setId(UUID.randomUUID());
+            return asset;
+        });
+        doNothing().when(storageService).uploadToRaw(any(), any());
+        doNothing().when(jobService).enqueue(any(), any(), any());
+
+        MockMultipartFile file = new MockMultipartFile("file", "sample.mp3", "audio/mpeg", "data".getBytes());
+
+        uploadService.uploadLocal("owner", null, file, "upload", false);
+
+        ArgumentCaptor<Media> mediaCaptor = ArgumentCaptor.forClass(Media.class);
+        verify(mediaRepository).saveAndFlush(mediaCaptor.capture());
+        verify(mediaRepository).save(mediaCaptor.capture());
+
+        assertThat(mediaCaptor.getAllValues())
+                .allMatch(media -> media.getSpeakerMode() == SpeakerMode.SINGLE);
+        assertThat(mediaCaptor.getValue().getStatus()).isEqualTo(MediaStatus.UPLOADED);
+    }
+
+    @Test
+    void uploadLocalSetsMultiSpeakerWhenFlagTrue() throws Exception {
+        UploadService uploadService = new UploadService(
+                storageService,
+                accountRepository,
+                mediaRepository,
+                assetRepository,
+                jobRepository,
+                jobService
+        );
+
+        Account owner = new Account("owner", "owner");
+        when(accountRepository.findByExternalSubject("owner")).thenReturn(Optional.of(owner));
+        when(mediaRepository.saveAndFlush(any(Media.class))).thenAnswer(invocation -> {
+            Media media = invocation.getArgument(0, Media.class);
+            media.setId(UUID.randomUUID());
+            return media;
+        });
+        when(mediaRepository.save(any(Media.class))).thenAnswer(invocation -> invocation.getArgument(0, Media.class));
+        when(assetRepository.save(any(Asset.class))).thenAnswer(invocation -> {
+            Asset asset = invocation.getArgument(0, Asset.class);
+            asset.setId(UUID.randomUUID());
+            return asset;
+        });
+        doNothing().when(storageService).uploadToRaw(any(), any());
+        doNothing().when(jobService).enqueue(any(), any(), any());
+
+        MockMultipartFile file = new MockMultipartFile("file", "sample.mp3", "audio/mpeg", "data".getBytes());
+
+        uploadService.uploadLocal("owner", null, file, "upload", true);
+
+        ArgumentCaptor<Media> mediaCaptor = ArgumentCaptor.forClass(Media.class);
+        verify(mediaRepository).saveAndFlush(mediaCaptor.capture());
+        verify(mediaRepository).save(mediaCaptor.capture());
+
+        assertThat(mediaCaptor.getAllValues())
+                .allMatch(media -> media.getSpeakerMode() == SpeakerMode.MULTI);
+        assertThat(mediaCaptor.getValue().getStatus()).isEqualTo(MediaStatus.UPLOADED);
+    }
+}
+

--- a/src/test/java/com/example/clipbot_backend/service/WorkerServiceTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/WorkerServiceTest.java
@@ -1,0 +1,140 @@
+package com.example.clipbot_backend.service;
+
+import com.example.clipbot_backend.engine.Interfaces.ClipRenderEngine;
+import com.example.clipbot_backend.engine.Interfaces.DetectionEngine;
+import com.example.clipbot_backend.engine.Interfaces.TranscriptionEngine;
+import com.example.clipbot_backend.model.Job;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.repository.*;
+import com.example.clipbot_backend.service.Interfaces.StorageService;
+import com.example.clipbot_backend.service.Interfaces.SubtitleService;
+import com.example.clipbot_backend.util.JobType;
+import com.example.clipbot_backend.util.SpeakerMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkerServiceTest {
+
+    @Mock
+    private JobService jobService;
+    @Mock
+    private TranscriptService transcriptService;
+    @Mock
+    private MediaRepository mediaRepository;
+    @Mock
+    private TranscriptRepository transcriptRepository;
+    @Mock
+    private SegmentRepository segmentRepository;
+    @Mock
+    private ClipRepository clipRepository;
+    @Mock
+    private AssetRepository assetRepository;
+    @Mock
+    private UrlDownloader urlDownloader;
+    @Mock
+    private FasterWhisperClient fasterWhisperClient;
+    @Mock
+    private AudioWindowService audioWindowService;
+    @Mock
+    private DetectWorkflow detectWorkflow;
+    @Mock
+    private ClipWorkFlow clipWorkFlow;
+    @Mock
+    private ClipService clipService;
+    @Mock
+    private DetectionEngine detectionEngine;
+    @Mock
+    private ClipRenderEngine clipRenderEngine;
+    @Mock
+    private StorageService storageService;
+    @Mock
+    private SubtitleService subtitleService;
+    @Mock
+    private RenderService renderService;
+    @Mock
+    private TranscriptionEngine gptDiarizeEngine;
+    @Mock
+    private TranscriptionEngine fasterWhisperEngine;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void handleTranscribeUsesGptForMultiSpeaker() throws Exception {
+        WorkerService workerService = new WorkerService(
+                jobService,
+                transcriptService,
+                mediaRepository,
+                transcriptRepository,
+                segmentRepository,
+                clipRepository,
+                assetRepository,
+                urlDownloader,
+                fasterWhisperClient,
+                audioWindowService,
+                detectWorkflow,
+                clipWorkFlow,
+                clipService,
+                detectionEngine,
+                clipRenderEngine,
+                storageService,
+                subtitleService,
+                renderService,
+                gptDiarizeEngine,
+                fasterWhisperEngine
+        );
+
+        UUID mediaId = UUID.randomUUID();
+        Media media = new Media();
+        media.setId(mediaId);
+        media.setObjectKey("sample.raw");
+        media.setSource("upload");
+        media.setSpeakerMode(SpeakerMode.MULTI);
+
+        Job job = new Job(JobType.TRANSCRIBE);
+        job.setId(UUID.randomUUID());
+        job.setMedia(media);
+
+        Path rawFile = Files.createTempFile(tempDir, "media", ".mp3");
+        when(storageService.resolveRaw("sample.raw")).thenReturn(rawFile);
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media));
+        when(transcriptService.existsAnyFor(mediaId)).thenReturn(false);
+
+        TranscriptionEngine.Result result = new TranscriptionEngine.Result(
+                "hello",
+                List.of(),
+                "nl",
+                "gpt_diarize",
+                Map.of()
+        );
+        when(gptDiarizeEngine.transcribe(any())).thenReturn(result);
+
+        workerService.handleTranscribe(job);
+
+        verify(gptDiarizeEngine).transcribe(any(TranscriptionEngine.Request.class));
+        verify(fasterWhisperEngine, never()).transcribe(any());
+        verify(jobService).enqueue(eq(mediaId), eq(JobType.DETECT), satisfiesPayload(result));
+    }
+
+    private ArgumentMatcher<Map<String, Object>> satisfiesPayload(TranscriptionEngine.Result result) {
+        return payload -> result.lang().equals(payload.get("lang")) && result.provider().equals(payload.get("provider"));
+    }
+}


### PR DESCRIPTION
## Summary
- document the podcast/interview flag on the URL ingest request so its multi-speaker purpose is clear
- add MediaService unit tests covering single-speaker defaults and explicit multi-speaker selection for URL ingestion

## Testing
- mvn -q test *(fails: POM self-dependency in existing configuration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a8361ecc483319083e91e97b70d91)