### PR TITLE
Add podcast intent handling and speaker-aware scoring

### DIFF
--- a/src/main/java/com/example/clipbot_backend/config/AsrOpenAIConfig.java
+++ b/src/main/java/com/example/clipbot_backend/config/AsrOpenAIConfig.java
@@ -49,7 +49,7 @@ public class AsrOpenAIConfig {
         HttpClient httpClient = HttpClient.create(provider)
                 // ✅ forceer HTTP/1.1 (vermijdt bad_record_mac issues)
                 .protocol(HttpProtocol.HTTP11)
-                .compress(true)
+                .compress(false)
                 .responseTimeout(RESPONSE_TIMEOUT)
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MILLIS)
                 .resolver(DefaultAddressResolverGroup.INSTANCE)

--- a/src/main/java/com/example/clipbot_backend/config/AsrOpenAIConfig.java
+++ b/src/main/java/com/example/clipbot_backend/config/AsrOpenAIConfig.java
@@ -1,13 +1,8 @@
 package com.example.clipbot_backend.config;
 
-import com.example.clipbot_backend.engine.Interfaces.TranscriptionEngine;
-import com.example.clipbot_backend.engine.OpenAITranscriptionEngine;
-import com.example.clipbot_backend.service.Interfaces.StorageService;
-
 import io.netty.resolver.DefaultAddressResolverGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -78,13 +73,4 @@ public class AsrOpenAIConfig {
                 .codecs(c -> c.defaultCodecs().maxInMemorySize(32 * 1024 * 1024))
                 .build();
     }
-    @Bean
-    TranscriptionEngine transcriptionEngine(
-            OpenAIAudioProperties props,
-            StorageService storageService,
-            @Qualifier("openAiWebClient") WebClient openAiWebClient // ← expliciet deze client
-    ) {
-        return new OpenAITranscriptionEngine(storageService,openAiWebClient,props);
-    }
-
 }

--- a/src/main/java/com/example/clipbot_backend/config/AsrOpenAIConfig.java
+++ b/src/main/java/com/example/clipbot_backend/config/AsrOpenAIConfig.java
@@ -29,17 +29,21 @@ import io.netty.handler.timeout.WriteTimeoutHandler;
 public class AsrOpenAIConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(AsrOpenAIConfig.class);
     private static final int CONNECT_TIMEOUT_MILLIS = 10_000;
-    private static final Duration RESPONSE_TIMEOUT = Duration.ofMinutes(8);
-    private static final Duration READ_TIMEOUT = Duration.ofMinutes(8);
-    private static final Duration WRITE_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration RESPONSE_TIMEOUT = Duration.ofMinutes(45);
+    private static final Duration READ_TIMEOUT = Duration.ofMinutes(45);
+    private static final Duration WRITE_TIMEOUT = Duration.ofMinutes(45);
+    private static final int MAX_CONNECTIONS = 10;
+    private static final Duration PENDING_ACQUIRE_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration MAX_IDLE_TIME = Duration.ofSeconds(20);
+    private static final Duration MAX_LIFE_TIME = Duration.ofMinutes(50);
 
     @Bean("openAiWebClient")
     WebClient openAiWebClient(OpenAIAudioProperties props){
         ConnectionProvider provider = ConnectionProvider.builder("openai-http")
-                .maxConnections(10)
-                .pendingAcquireTimeout(Duration.ofSeconds(30))
-                .maxIdleTime(Duration.ofSeconds(20))
-                .maxLifeTime(Duration.ofMinutes(5))
+                .maxConnections(MAX_CONNECTIONS)
+                .pendingAcquireTimeout(PENDING_ACQUIRE_TIMEOUT)
+                .maxIdleTime(MAX_IDLE_TIME)
+                .maxLifeTime(MAX_LIFE_TIME)
                 .build();
 
         HttpClient httpClient = HttpClient.create(provider)
@@ -60,10 +64,10 @@ public class AsrOpenAIConfig {
                 RESPONSE_TIMEOUT.toSeconds(),
                 READ_TIMEOUT.toSeconds(),
                 WRITE_TIMEOUT.toSeconds(),
-                10,
-                Duration.ofSeconds(30).toSeconds(),
-                Duration.ofSeconds(20).toSeconds(),
-                Duration.ofMinutes(5).toSeconds()
+                MAX_CONNECTIONS,
+                PENDING_ACQUIRE_TIMEOUT.toSeconds(),
+                MAX_IDLE_TIME.toSeconds(),
+                MAX_LIFE_TIME.toSeconds()
         );
 
         return WebClient.builder()

--- a/src/main/java/com/example/clipbot_backend/config/AsrOpenAIConfig.java
+++ b/src/main/java/com/example/clipbot_backend/config/AsrOpenAIConfig.java
@@ -35,7 +35,7 @@ public class AsrOpenAIConfig {
     private static final int MAX_CONNECTIONS = 10;
     private static final Duration PENDING_ACQUIRE_TIMEOUT = Duration.ofSeconds(30);
     private static final Duration MAX_IDLE_TIME = Duration.ofSeconds(20);
-    private static final Duration MAX_LIFE_TIME = Duration.ofMinutes(50);
+    private static final Duration MAX_LIFE_TIME = Duration.ofMinutes(5);
 
     @Bean("openAiWebClient")
     WebClient openAiWebClient(OpenAIAudioProperties props){

--- a/src/main/java/com/example/clipbot_backend/config/OpenAIAudioProperties.java
+++ b/src/main/java/com/example/clipbot_backend/config/OpenAIAudioProperties.java
@@ -12,6 +12,7 @@ public class OpenAIAudioProperties {
     private String model = "gpt-4o-transcribe-diarize";
     private String language = "auto";
     private long timeoutSeconds = 300;
+    private Boolean diarize;
 
 
     public OpenAIAudioProperties() {
@@ -39,6 +40,17 @@ public class OpenAIAudioProperties {
 
     public void setModel(String model) {
         this.model = model;
+    }
+
+    public boolean isDiarize() {
+        if (diarize != null) {
+            return diarize;
+        }
+        return model != null && model.toLowerCase().contains("diarize");
+    }
+
+    public void setDiarize(Boolean diarize) {
+        this.diarize = diarize;
     }
 
     public String getLanguage() {

--- a/src/main/java/com/example/clipbot_backend/config/OpenAIAudioProperties.java
+++ b/src/main/java/com/example/clipbot_backend/config/OpenAIAudioProperties.java
@@ -11,7 +11,7 @@ public class OpenAIAudioProperties {
     private String apiKey;
     private String model = "gpt-4o-transcribe-diarize";
     private String language = "auto";
-    private long timeoutSeconds = 300;
+    private long timeoutSeconds = 2700;
     private Boolean diarize;
 
 

--- a/src/main/java/com/example/clipbot_backend/config/OpenAIAudioProperties.java
+++ b/src/main/java/com/example/clipbot_backend/config/OpenAIAudioProperties.java
@@ -13,6 +13,7 @@ public class OpenAIAudioProperties {
     private String language = "auto";
     private long timeoutSeconds = 2700;
     private Boolean diarize;
+    private boolean logDiarizeResponse = false;
 
 
     public OpenAIAudioProperties() {
@@ -67,5 +68,13 @@ public class OpenAIAudioProperties {
 
     public void setTimeoutSeconds(long timeoutSeconds) {
         this.timeoutSeconds = timeoutSeconds;
+    }
+
+    public boolean isLogDiarizeResponse() {
+        return logDiarizeResponse;
+    }
+
+    public void setLogDiarizeResponse(boolean logDiarizeResponse) {
+        this.logDiarizeResponse = logDiarizeResponse;
     }
 }

--- a/src/main/java/com/example/clipbot_backend/controller/DetectController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/DetectController.java
@@ -86,7 +86,7 @@ public class DetectController {
   }
 
   private void ensureOwnedBy(UUID mediaId, String subject) {
-    var media = mediaRepo.findById(mediaId)
+    var media = mediaRepo.findByIdWithOwner(mediaId)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "MEDIA_NOT_FOUND"));
     if (isAdmin(subject)) return; // admin bypass
     var ownerSub = media.getOwner().getExternalSubject();

--- a/src/main/java/com/example/clipbot_backend/controller/MediaController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/MediaController.java
@@ -10,6 +10,7 @@ import com.example.clipbot_backend.service.metadata.MetadataResult;
 import com.example.clipbot_backend.service.metadata.MetadataService;
 import com.example.clipbot_backend.util.MediaPlatform;
 import com.example.clipbot_backend.util.MediaStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -43,8 +44,14 @@ public class MediaController {
         final MediaPlatform platform = (md != null ? md.platform() : metadataService.detectPlatform(request.url()));
         final Long durationMs = (md != null && md.durationSec() != null) ? safeToMillis(md.durationSec()) : null;
 
+        SpeakerMode speakerMode = Boolean.TRUE.equals(request.podcastOrInterview()) ? SpeakerMode.MULTI : SpeakerMode.SINGLE;
+        if (SpeakerMode.MULTI.equals(speakerMode)) {
+            org.slf4j.LoggerFactory.getLogger(MediaController.class)
+                    .info("INGEST from-url podcastOrInterview=true speakerMode=MULTI ownerId={} url={}", request.ownerId(), normalizedUrl);
+        }
+
         UUID mediaId = mediaService.createMediaFromUrl(
-                request.ownerId(), normalizedUrl, platform, source, durationMs, request.objectKeyOverride()
+                request.ownerId(), normalizedUrl, platform, source, durationMs, request.objectKeyOverride(), speakerMode
         );
         Media media = mediaService.get(mediaId);
         // Service zet DOWNLOADING; dat moeten we zo teruggeven:

--- a/src/main/java/com/example/clipbot_backend/controller/MediaController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/MediaController.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/v1/media")
 public class MediaController {
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(MediaController.class);
     private final MediaService mediaService;
     private final MetadataService metadataService;
     private final AccountService accountService;
@@ -51,8 +52,7 @@ public class MediaController {
         SpeakerMode speakerMode = Boolean.TRUE.equals(request.podcastOrInterview()) ? SpeakerMode.MULTI : SpeakerMode.SINGLE;
         Account owner = resolveOwner(request);
         if (SpeakerMode.MULTI.equals(speakerMode)) {
-            org.slf4j.LoggerFactory.getLogger(MediaController.class)
-                    .info("INGEST from-url podcastOrInterview=true speakerMode=MULTI ownerId={} url={}", owner.getId(), normalizedUrl);
+            LOGGER.info("INGEST from-url podcastOrInterview=true speakerMode=MULTI ownerId={} url={}", owner.getId(), normalizedUrl);
         }
 
         UUID mediaId = mediaService.createMediaFromUrl(
@@ -120,6 +120,7 @@ public class MediaController {
                 if (ownerExternalSubject != null && !ownerIdRaw.equals(ownerExternalSubject)) {
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "OWNER_CONFLICT");
                 }
+                LOGGER.debug("OwnerId '{}' is not a UUID; resolving as externalSubject", ownerIdRaw);
                 return accountService.getByExternalSubjectOrThrow(ownerIdRaw);
             }
         }
@@ -132,7 +133,7 @@ public class MediaController {
     }
 
     private String normalize(String value) {
-        return (value == null || value.isBlank()) ? null : value;
+        return (value == null) ? null : value.trim().isBlank() ? null : value.trim();
     }
 
 

--- a/src/main/java/com/example/clipbot_backend/controller/UploadController.java
+++ b/src/main/java/com/example/clipbot_backend/controller/UploadController.java
@@ -31,8 +31,9 @@ public class UploadController {
             @RequestParam("owner") String ownerExternalSubject,
             @RequestParam(value = "objectKey", required = false) String objectKey,
             @RequestPart("file") MultipartFile file,
-            @RequestParam(value = "source", required = false, defaultValue = "upload") String source) throws Exception {
-        return uploadService.uploadLocal(ownerExternalSubject, objectKey, file, source);
+            @RequestParam(value = "source", required = false, defaultValue = "upload") String source,
+            @RequestParam(value = "podcastOrInterview", required = false) Boolean podcastOrInterview) throws Exception {
+        return uploadService.uploadLocal(ownerExternalSubject, objectKey, file, source, podcastOrInterview);
     }
 
 

--- a/src/main/java/com/example/clipbot_backend/dto/DetectionParams.java
+++ b/src/main/java/com/example/clipbot_backend/dto/DetectionParams.java
@@ -15,7 +15,8 @@ public record DetectionParams(
                               // scene change
                               double sceneThreshold,
                               long   snapSceneMs,
-                              double sceneAlignBonus
+                              double sceneAlignBonus,
+                              boolean speakerTurnsEnabled
 
 ) {
     // Compacte ctor voor defaults + guard rails
@@ -36,18 +37,31 @@ public record DetectionParams(
         snapSceneMs     = (snapSceneMs     > 0) ? snapSceneMs      : 400;
         sceneAlignBonus = (sceneAlignBonus > 0) ? sceneAlignBonus  : 0.12;
 
+        speakerTurnsEnabled = speakerTurnsEnabled;
+
         // Basisvalidatie
         if (minDurationMs >= maxDurationMs)
             throw new IllegalArgumentException("minDurationMs must be < maxDurationMs");
     }
     // Handige named factory voor defaults (optioneel)
-    public static DetectionParams defaults() { return new DetectionParams(0,0,0,0,0,0,0,0,0,0,0); }
+    public static DetectionParams defaults() { return new DetectionParams(0,0,0,0,0,0,0,0,0,0,0,false); }
 
     // "withers" voor fluency (optioneel)
     public DetectionParams withMaxCandidates(int n) { return new DetectionParams(
             minDurationMs, maxDurationMs, n,
             silenceNoiseDb, silenceMinDurSec, snapThresholdMs,
             targetLenSec, lenSigmaSec,
-            sceneThreshold, snapSceneMs, sceneAlignBonus
+            sceneThreshold, snapSceneMs, sceneAlignBonus,
+            speakerTurnsEnabled
     );}
+
+    public DetectionParams withSpeakerTurnsEnabled(boolean enabled) {
+        return new DetectionParams(
+                minDurationMs, maxDurationMs, maxCandidates,
+                silenceNoiseDb, silenceMinDurSec, snapThresholdMs,
+                targetLenSec, lenSigmaSec,
+                sceneThreshold, snapSceneMs, sceneAlignBonus,
+                enabled
+        );
+    }
 }

--- a/src/main/java/com/example/clipbot_backend/dto/SpeakerTurn.java
+++ b/src/main/java/com/example/clipbot_backend/dto/SpeakerTurn.java
@@ -1,0 +1,4 @@
+package com.example.clipbot_backend.dto;
+
+public record SpeakerTurn(String speaker, long startMs, long endMs) {
+}

--- a/src/main/java/com/example/clipbot_backend/dto/WordsParser.java
+++ b/src/main/java/com/example/clipbot_backend/dto/WordsParser.java
@@ -60,6 +60,23 @@ public final class WordsParser {
         return out;
     }
 
+    public static List<SpeakerTurn> extractSpeakerTurns(Transcript transcript) {
+        if (transcript == null || transcript.getWords() == null) return List.of();
+        JsonNode root = transcript.getWords();
+        JsonNode segs = root.path("segments");
+        if (!segs.isArray() || segs.isEmpty()) return List.of();
+        List<SpeakerTurn> turns = new ArrayList<>();
+        for (JsonNode s : segs) {
+            long start = pickMs(s.get("startMs"), s.get("start"));
+            long end = pickMs(s.get("endMs"), s.get("end"));
+            String speaker = firstText(s, "speaker", "spk");
+            if (end <= start) continue;
+            turns.add(new SpeakerTurn(speaker == null ? "" : speaker, start, end));
+        }
+        turns.sort(Comparator.comparingLong(SpeakerTurn::startMs));
+        return turns;
+    }
+
 
     /* ---------- helpers ---------- */
 

--- a/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
@@ -24,6 +24,6 @@ public record MediaFromUrlRequest(
     }
 
     private boolean hasText(String value) {
-        return value != null && !value.isBlank();
+        return value != null && !value.trim().isBlank();
     }
 }

--- a/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
@@ -4,10 +4,8 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-import java.util.UUID;
-
 public record MediaFromUrlRequest(
-        UUID ownerId,
+        String ownerId,
         String ownerExternalSubject,
         @NotBlank @Size(max = 2048) String url,
         String source,
@@ -17,11 +15,15 @@ public record MediaFromUrlRequest(
 
     @AssertTrue(message = "Either ownerId or ownerExternalSubject is required")
     public boolean hasOwner() {
-        return ownerId != null || (ownerExternalSubject != null && !ownerExternalSubject.isBlank());
+        return hasText(ownerId) || hasText(ownerExternalSubject);
     }
 
     @AssertTrue(message = "Provide either ownerId or ownerExternalSubject, not both")
     public boolean onlyOneOwnerProvided() {
-        return !(ownerId != null && ownerExternalSubject != null && !ownerExternalSubject.isBlank());
+        return !(hasText(ownerId) && hasText(ownerExternalSubject));
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 }

--- a/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
@@ -10,6 +10,7 @@ public record MediaFromUrlRequest(
         @NotNull UUID ownerId,
         @NotBlank @Size(max = 2048) String url,
         String source,
-        String objectKeyOverride
+        String objectKeyOverride,
+        Boolean podcastOrInterview
 ) {
 }

--- a/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
+++ b/src/main/java/com/example/clipbot_backend/dto/web/MediaFromUrlRequest.java
@@ -1,16 +1,27 @@
 package com.example.clipbot_backend.dto.web;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.util.UUID;
 
 public record MediaFromUrlRequest(
-        @NotNull UUID ownerId,
+        UUID ownerId,
+        String ownerExternalSubject,
         @NotBlank @Size(max = 2048) String url,
         String source,
         String objectKeyOverride,
         Boolean podcastOrInterview
 ) {
+
+    @AssertTrue(message = "Either ownerId or ownerExternalSubject is required")
+    public boolean hasOwner() {
+        return ownerId != null || (ownerExternalSubject != null && !ownerExternalSubject.isBlank());
+    }
+
+    @AssertTrue(message = "Provide either ownerId or ownerExternalSubject, not both")
+    public boolean onlyOneOwnerProvided() {
+        return !(ownerId != null && ownerExternalSubject != null && !ownerExternalSubject.isBlank());
+    }
 }

--- a/src/main/java/com/example/clipbot_backend/engine/Interfaces/GptDiarizeTranscriptionEngine.java
+++ b/src/main/java/com/example/clipbot_backend/engine/Interfaces/GptDiarizeTranscriptionEngine.java
@@ -46,6 +46,7 @@ public class GptDiarizeTranscriptionEngine implements TranscriptionEngine {
         form.add("file", new FileSystemResource(input));
         form.add("model", props.getModel());
         form.add("response_format", "diarized_json");
+        form.add("chunking_strategy", "auto");
         form.add("diarization", true);
         if (request.langHint() != null && !request.langHint().isBlank()) {
             form.add("language", request.langHint());

--- a/src/main/java/com/example/clipbot_backend/engine/Interfaces/GptDiarizeTranscriptionEngine.java
+++ b/src/main/java/com/example/clipbot_backend/engine/Interfaces/GptDiarizeTranscriptionEngine.java
@@ -2,6 +2,8 @@ package com.example.clipbot_backend.engine.Interfaces;
 
 import com.example.clipbot_backend.config.OpenAIAudioProperties;
 import com.example.clipbot_backend.service.Interfaces.StorageService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,9 +17,11 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-
+import reactor.netty.http.client.PrematureCloseException;
+import reactor.util.retry.Retry;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -27,9 +31,12 @@ import java.util.Map;
 @Qualifier("gptDiarizeEngine")
 public class GptDiarizeTranscriptionEngine implements TranscriptionEngine {
     private static final Logger log = LoggerFactory.getLogger(GptDiarizeTranscriptionEngine.class);
+    private static final Duration RETRY_BACKOFF = Duration.ofMillis(200);
+    private static final int RETRY_MAX_ATTEMPTS = 2;
     private final StorageService storage;
     private final WebClient openAiClient;
     private final OpenAIAudioProperties props;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public GptDiarizeTranscriptionEngine(StorageService storage, @Qualifier("openAiWebClient")WebClient openAiClient, OpenAIAudioProperties props) {
         this.storage = storage;
@@ -52,27 +59,34 @@ public class GptDiarizeTranscriptionEngine implements TranscriptionEngine {
             form.add("language", request.langHint());
         }
 
-        ResponseWithStatus response = openAiClient.post()
+        Mono<JsonNode> mono = openAiClient.post()
                 .uri("/v1/audio/transcriptions")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(BodyInserters.fromMultipartData(form))
                 .exchangeToMono(this::deserializeResponse)
-                .block();
+                .flatMap(resp -> {
+                    if (!resp.status().is2xxSuccessful()) {
+                        log.error("OpenAI transcription failed status={} mediaId={} objectKey={} body={}",
+                                resp.status().value(), request.mediaId(), request.objectKey(), truncate(resp.body(), 2_000));
+                        return Mono.error(new IllegalStateException("OpenAI transcription failed: status=" + resp.status().value()
+                                + " body=" + truncate(resp.body(), 2_000)));
+                    }
+                    try {
+                        return Mono.just(parseJson(resp.body(), request));
+                    } catch (RuntimeException ex) {
+                        return Mono.error(ex);
+                    }
+                })
+                .retryWhen(Retry.backoff(RETRY_MAX_ATTEMPTS, RETRY_BACKOFF)
+                        .filter(this::isRetryable)
+                        .doBeforeRetry(signal -> log.warn(
+                                "GPT diarize retry attempt={} mediaId={} cause={}",
+                                signal.totalRetriesInARow() + 1,
+                                request.mediaId(),
+                                signal.failure() == null ? "unknown" : signal.failure().toString()
+                        )));
 
-        if (response == null) {
-            throw new IllegalStateException("OpenAI transcription returned no response body for objectKey=" + request.objectKey());
-        }
-
-        if (!response.status().is2xxSuccessful()) {
-            log.error("OpenAI transcription failed status={} mediaId={} objectKey={} body={}",
-                    response.status().value(), request.mediaId(), request.objectKey(), response.body());
-            throw new IllegalStateException("OpenAI transcription failed: status=" + response.status().value()
-                    + " body=" + response.body());
-        }
-
-        String json = response.body();
-
-        var root = new ObjectMapper().readTree(json);
+        JsonNode root = mono.block();
         String text = root.path("text").asText("");
         String lang = root.path("language").asText("auto");
 
@@ -109,16 +123,45 @@ public class GptDiarizeTranscriptionEngine implements TranscriptionEngine {
     private Mono<ResponseWithStatus> deserializeResponse(ClientResponse clientResponse) {
         return clientResponse.bodyToMono(String.class)
                 .defaultIfEmpty("")
-                .map(body -> new ResponseWithStatus(clientResponse.statusCode(), truncateBody(body)));
-    }
-
-    private String truncateBody(String body) {
-        int max = 2_000;
-        if (body == null) {
-            return "";
-        }
-        return body.length() > max ? body.substring(0, max) + "..." : body;
+                .map(body -> new ResponseWithStatus(clientResponse.statusCode(), body));
     }
 
     private record ResponseWithStatus(HttpStatusCode status, String body) {}
+
+    private JsonNode parseJson(String body, Request request) {
+        try {
+            return objectMapper.readTree(body);
+        } catch (JsonProcessingException e) {
+            String snippet = truncate(body, 500);
+            int length = body == null ? 0 : body.length();
+            log.warn("GPT diarize parse failure mediaId={} length={} snippet={}", request.mediaId(), length, snippet);
+            throw new OpenAITruncatedResponseException("OPENAI_TRUNCATED_RESPONSE length=" + length + " snippet=" + snippet, e);
+        }
+    }
+
+    private static String truncate(String body, int max) {
+        if (body == null) return "";
+        if (body.length() <= max) return body;
+        return body.substring(0, max) + "...";
+    }
+
+    private boolean isRetryable(Throwable throwable) {
+        if (throwable instanceof PrematureCloseException) {
+            return true;
+        }
+        if (throwable instanceof org.springframework.web.reactive.function.client.WebClientRequestException reqEx
+                && reqEx.getCause() instanceof PrematureCloseException) {
+            return true;
+        }
+        if (throwable instanceof OpenAITruncatedResponseException) {
+            return true;
+        }
+        return false;
+    }
+
+    private static class OpenAITruncatedResponseException extends RuntimeException {
+        OpenAITruncatedResponseException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
 }

--- a/src/main/java/com/example/clipbot_backend/engine/Interfaces/GptDiarizeTranscriptionEngine.java
+++ b/src/main/java/com/example/clipbot_backend/engine/Interfaces/GptDiarizeTranscriptionEngine.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.FileSystemResource;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -113,5 +113,5 @@ public class GptDiarizeTranscriptionEngine implements TranscriptionEngine {
         return body.length() > max ? body.substring(0, max) + "..." : body;
     }
 
-    private record ResponseWithStatus(HttpStatus status, String body) {}
+    private record ResponseWithStatus(HttpStatusCode status, String body) {}
 }

--- a/src/main/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngine.java
+++ b/src/main/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngine.java
@@ -82,8 +82,8 @@ public class OpenAITranscriptionEngine implements TranscriptionEngine {
                     .bodyToMono(String.class)
                     .doOnNext(body -> {
                         if (logDiarize) {
-                            LOGGER.debug("OpenAI diarize raw response mediaId={} length={} snippet={}", request.mediaId(),
-                                    body == null ? 0 : body.length(), truncate(body, 5000));
+                            LOGGER.info("OpenAI diarize raw response mediaId={} length={} snippet={}", request.mediaId(),
+                                    body == null ? 0 : body.length(), truncate(body, 2000));
                         }
                     })
                     .map(body -> parseJson(body, request))
@@ -332,18 +332,18 @@ public class OpenAITranscriptionEngine implements TranscriptionEngine {
             try {
                 List<String> fields = new ArrayList<>();
                 root.fieldNames().forEachRemaining(fields::add);
-                LOGGER.debug("OpenAI diarize parsed root mediaId={} fields={}", request.mediaId(), fields);
+                LOGGER.info("OpenAI diarize parsed root mediaId={} fields={}", request.mediaId(), fields);
 
                 JsonNode segments = extractDiarizeSegments(root, request);
                 if (segments != null && segments.isArray() && segments.size() > 0) {
                     JsonNode first = segments.get(0);
                     String serialized = om.writeValueAsString(first);
-                    LOGGER.debug("OpenAI diarize first segment mediaId={} snippet={}", request.mediaId(), truncate(serialized, 2000));
+                    LOGGER.info("OpenAI diarize first segment mediaId={} snippet={}", request.mediaId(), truncate(serialized, 2000));
                 } else {
-                    LOGGER.debug("OpenAI diarize segments missing or empty mediaId={}", request.mediaId());
+                    LOGGER.info("OpenAI diarize segments missing or empty mediaId={}", request.mediaId());
                 }
             } catch (Exception e) {
-                LOGGER.debug("OpenAI diarize logging failed mediaId={} error={}", request.mediaId(), e.toString());
+                LOGGER.info("OpenAI diarize logging failed mediaId={} error={}", request.mediaId(), e.toString());
             }
         }
 

--- a/src/main/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngine.java
+++ b/src/main/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngine.java
@@ -60,6 +60,7 @@ import java.util.*;
 
             if (diarize) {
                 form.add("response_format", "diarized_json");
+                form.add("chunking_strategy", "auto");
             } else {
                 form.add("response_format", "verbose_json");
                 form.add("timestamp_granularities[]", "word");

--- a/src/main/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngine.java
+++ b/src/main/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngine.java
@@ -29,7 +29,7 @@ import java.util.*;
     public class OpenAITranscriptionEngine implements TranscriptionEngine {
         private static final Logger LOGGER = LoggerFactory.getLogger(OpenAITranscriptionEngine.class);
         private static final Duration RETRY_BACKOFF = Duration.ofMillis(200);
-        private static final Duration MIN_BLOCK_TIMEOUT = Duration.ofMinutes(8);
+        private static final Duration MIN_BLOCK_TIMEOUT = Duration.ofMinutes(45);
         private final StorageService storageService;
         private final WebClient client;
         private final OpenAIAudioProperties props;

--- a/src/main/java/com/example/clipbot_backend/model/Media.java
+++ b/src/main/java/com/example/clipbot_backend/model/Media.java
@@ -56,7 +56,7 @@ public class Media {
     private Integer speakerCountDetected;
 
     @Enumerated(EnumType.STRING)
-    private SpeakerMode speakerMode = AUTO;
+    private SpeakerMode speakerMode = SINGLE;
 
     public Media(UUID id, Account owner, String objectKey, Long durationMs,String source, Instant createdAt) {
         this.id = id;
@@ -163,12 +163,7 @@ public class Media {
 
     @Transient
     public boolean isMultiSpeakerEffective() {
-        SpeakerMode mode = this.speakerMode != null ? this.speakerMode : SpeakerMode.AUTO;
-        return switch (mode) {
-            case MULTI  -> true;                                  // Interview/Podcast
-            case SINGLE -> false;                                 // Monologue
-            case AUTO   -> (speakerCountDetected != null && speakerCountDetected > 1);
-        };
+        return SpeakerMode.MULTI.equals(this.speakerMode);
     }
 }
 

--- a/src/main/java/com/example/clipbot_backend/service/ClipAssembler.java
+++ b/src/main/java/com/example/clipbot_backend/service/ClipAssembler.java
@@ -27,7 +27,8 @@ public class ClipAssembler {
                                 List<SilenceEvent> silences,
                                 long minMs, long maxMs, long snapThreshMs,
                                 double targetLenSec, double sigmaSec,
-                                int maxCandidates) {
+                                int maxCandidates,
+                                HeuristicScorer.SpeakerContext speakerContext) {
 
         List<Window> out = new ArrayList<>();
         if (sentences.isEmpty()) return out;
@@ -44,7 +45,7 @@ public class ClipAssembler {
                 if (sSnap>=0) s = sSnap;
                 if (eSnap>=0) e = eSnap;
 
-                var comp = scorer.scoreWindow(sentences.subList(i, j+1), targetLenSec, sigmaSec);
+                var comp = scorer.scoreWindow(sentences.subList(i, j+1), targetLenSec, sigmaSec, speakerContext, s, e);
                 if (comp.overall() <= 0.0) continue;
 
                 out.add(new Window(i,j,s,e,comp.overall(), comp.toMeta()));
@@ -84,7 +85,8 @@ public class ClipAssembler {
             List<SentenceSpan> sentences,
             long minMs, long maxMs,
             double targetLenSec, double sigmaSec,
-            int maxCandidates
+            int maxCandidates,
+            HeuristicScorer.SpeakerContext speakerContext
     ) {
         List<Window> out = new ArrayList<>();
         if (sentences == null || sentences.isEmpty()) return out;
@@ -111,7 +113,7 @@ public class ClipAssembler {
 
                 // 2) Score berekenen
                 var slice = sentences.subList(i, j + 1);
-                var comp = scorer.scoreWindow(slice, targetLenSec, sigmaSec);
+                var comp = scorer.scoreWindow(slice, targetLenSec, sigmaSec, speakerContext, start, end);
                 double score = Math.max(0.01, comp.overall());
                 if (score < 0.05) continue; // mini-threshold voorkomt ruis
 

--- a/src/main/java/com/example/clipbot_backend/service/DetectWorkflow.java
+++ b/src/main/java/com/example/clipbot_backend/service/DetectWorkflow.java
@@ -75,7 +75,8 @@ public class DetectWorkflow {
                     media.getId());
 
             Path srcPath = requireRaw(media);
-            DetectionParams params = buildParams(payload);
+            DetectionParams params = buildParams(payload).withSpeakerTurnsEnabled(media.isMultiSpeakerEffective());
+            LOGGER.debug("DETECT params speakerTurnsEnabled={} media={}", params.speakerTurnsEnabled(), media.getId());
             var detected = detection.detect(srcPath, tr, params);
 
             var refined = refineWithWordBounds(srcPath, detected, tr);
@@ -215,7 +216,8 @@ public class DetectWorkflow {
                 minMs, maxMs, maxCand,
                 silDb, silMin, snapMs,
                 target, sigma,
-                sceneT, snapSc, scBonus
+                sceneT, snapSc, scBonus,
+                false
         );
     }
 

--- a/src/main/java/com/example/clipbot_backend/service/DetectWorkflow.java
+++ b/src/main/java/com/example/clipbot_backend/service/DetectWorkflow.java
@@ -5,17 +5,20 @@ import com.example.clipbot_backend.dto.SegmentDTO;
 import com.example.clipbot_backend.dto.WordsParser;
 import com.example.clipbot_backend.engine.Interfaces.DetectionEngine;
 import com.example.clipbot_backend.engine.Interfaces.TranscriptionEngine;
+import com.example.clipbot_backend.dto.FwVerboseResponse;
 import com.example.clipbot_backend.model.Media;
 import com.example.clipbot_backend.model.Segment;
 import com.example.clipbot_backend.model.Transcript;
 import com.example.clipbot_backend.repository.MediaRepository;
 import com.example.clipbot_backend.repository.SegmentRepository;
 import com.example.clipbot_backend.repository.TranscriptRepository;
-import com.example.clipbot_backend.service.Interfaces.TranscriptService;
+import com.example.clipbot_backend.service.FasterWhisperClient;
 import com.example.clipbot_backend.service.Interfaces.StorageService;
 import com.example.clipbot_backend.service.RecommendationService;
+import com.example.clipbot_backend.service.TranscriptService;
 import com.example.clipbot_backend.service.thumbnail.ThumbnailService;
 import com.example.clipbot_backend.util.MediaStatus;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -38,17 +41,18 @@ public class DetectWorkflow {
     private final SegmentRepository segmentRepo;
     private final StorageService storage;
     private final DetectionEngine detection;
-    private final TranscriptionService transcriptService;
+    private final TranscriptService transcriptService;
     private final TranscriptionEngine gptDiarizeEngine;
     private final TranscriptionEngine fasterWhisperEngine;
     private final AudioWindowService audioWindowService;
+    private final FasterWhisperClient fastWhisperClient;
     private final UrlDownloader urlDownloader;
     private final RecommendationService recommendationService;
     private final ThumbnailService thumbnailService;
 
     private static final int DEFAULT_TOP_N = 6;
 
-    public DetectWorkflow(MediaRepository mediaRepo, TranscriptRepository transcriptRepo, SegmentRepository segmentRepo, StorageService storage, DetectionEngine detection, TranscriptionService transcriptService, @Qualifier("gptDiarizeEngine") TranscriptionEngine gptDiarizeEngine, @Qualifier("fasterWhisperEngine") TranscriptionEngine fasterWhisperEngine, AudioWindowService audioWindowService, UrlDownloader urlDownloader, RecommendationService recommendationService, ThumbnailService thumbnailService) {
+    public DetectWorkflow(MediaRepository mediaRepo, TranscriptRepository transcriptRepo, SegmentRepository segmentRepo, StorageService storage, DetectionEngine detection, TranscriptService transcriptService, @Qualifier("gptDiarizeEngine") TranscriptionEngine gptDiarizeEngine, @Qualifier("fasterWhisperEngine") TranscriptionEngine fasterWhisperEngine, AudioWindowService audioWindowService, FasterWhisperClient fastWhisperClient, UrlDownloader urlDownloader, RecommendationService recommendationService, ThumbnailService thumbnailService) {
         this.mediaRepo = mediaRepo;
         this.transcriptRepo = transcriptRepo;
         this.segmentRepo = segmentRepo;
@@ -58,6 +62,7 @@ public class DetectWorkflow {
         this.gptDiarizeEngine = gptDiarizeEngine;
         this.fasterWhisperEngine = fasterWhisperEngine;
         this.audioWindowService = audioWindowService;
+        this.fastWhisperClient = fastWhisperClient;
         this.urlDownloader = urlDownloader;
         this.recommendationService = recommendationService;
         this.thumbnailService = thumbnailService;

--- a/src/main/java/com/example/clipbot_backend/service/DetectWorkflow.java
+++ b/src/main/java/com/example/clipbot_backend/service/DetectWorkflow.java
@@ -14,6 +14,7 @@ import com.example.clipbot_backend.repository.TranscriptRepository;
 import com.example.clipbot_backend.service.Interfaces.TranscriptService;
 import com.example.clipbot_backend.service.Interfaces.StorageService;
 import com.example.clipbot_backend.service.RecommendationService;
+import com.example.clipbot_backend.service.thumbnail.ThumbnailService;
 import com.example.clipbot_backend.util.MediaStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,10 +44,11 @@ public class DetectWorkflow {
     private final AudioWindowService audioWindowService;
     private final UrlDownloader urlDownloader;
     private final RecommendationService recommendationService;
+    private final ThumbnailService thumbnailService;
 
     private static final int DEFAULT_TOP_N = 6;
 
-    public DetectWorkflow(MediaRepository mediaRepo, TranscriptRepository transcriptRepo, SegmentRepository segmentRepo, StorageService storage, DetectionEngine detection, TranscriptionService transcriptService, @Qualifier("gptDiarizeEngine") TranscriptionEngine gptDiarizeEngine, @Qualifier("fasterWhisperEngine") TranscriptionEngine fasterWhisperEngine, AudioWindowService audioWindowService, UrlDownloader urlDownloader, RecommendationService recommendationService) {
+    public DetectWorkflow(MediaRepository mediaRepo, TranscriptRepository transcriptRepo, SegmentRepository segmentRepo, StorageService storage, DetectionEngine detection, TranscriptionService transcriptService, @Qualifier("gptDiarizeEngine") TranscriptionEngine gptDiarizeEngine, @Qualifier("fasterWhisperEngine") TranscriptionEngine fasterWhisperEngine, AudioWindowService audioWindowService, UrlDownloader urlDownloader, RecommendationService recommendationService, ThumbnailService thumbnailService) {
         this.mediaRepo = mediaRepo;
         this.transcriptRepo = transcriptRepo;
         this.segmentRepo = segmentRepo;
@@ -58,6 +60,7 @@ public class DetectWorkflow {
         this.audioWindowService = audioWindowService;
         this.urlDownloader = urlDownloader;
         this.recommendationService = recommendationService;
+        this.thumbnailService = thumbnailService;
     }
 
     public int run(UUID mediaId, Map<String,Object> payload) throws Exception {
@@ -80,6 +83,7 @@ public class DetectWorkflow {
                     media.getId());
 
             Path srcPath = requireRaw(media);
+            thumbnailService.extractFromLocalMedia(media, srcPath);
             DetectionParams params = buildParams(payload).withSpeakerTurnsEnabled(isMulti);
             LOGGER.debug("DETECT params speakerTurnsEnabled={} media={}", params.speakerTurnsEnabled(), media.getId());
             var detected = detection.detect(srcPath, tr, params);

--- a/src/main/java/com/example/clipbot_backend/service/DetectWorkflow.java
+++ b/src/main/java/com/example/clipbot_backend/service/DetectWorkflow.java
@@ -1,23 +1,23 @@
 package com.example.clipbot_backend.service;
 
 import com.example.clipbot_backend.dto.DetectionParams;
-import com.example.clipbot_backend.dto.FwVerboseResponse;
 import com.example.clipbot_backend.dto.SegmentDTO;
 import com.example.clipbot_backend.dto.WordsParser;
 import com.example.clipbot_backend.engine.Interfaces.DetectionEngine;
+import com.example.clipbot_backend.engine.Interfaces.TranscriptionEngine;
 import com.example.clipbot_backend.model.Media;
 import com.example.clipbot_backend.model.Segment;
 import com.example.clipbot_backend.model.Transcript;
 import com.example.clipbot_backend.repository.MediaRepository;
 import com.example.clipbot_backend.repository.SegmentRepository;
 import com.example.clipbot_backend.repository.TranscriptRepository;
+import com.example.clipbot_backend.service.Interfaces.TranscriptService;
 import com.example.clipbot_backend.service.Interfaces.StorageService;
 import com.example.clipbot_backend.service.RecommendationService;
 import com.example.clipbot_backend.util.MediaStatus;
-import com.fasterxml.jackson.databind.JsonNode;
-import io.netty.handler.timeout.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,20 +37,24 @@ public class DetectWorkflow {
     private final SegmentRepository segmentRepo;
     private final StorageService storage;
     private final DetectionEngine detection;
-    private final FasterWhisperClient fastWhisperClient;
+    private final TranscriptionService transcriptService;
+    private final TranscriptionEngine gptDiarizeEngine;
+    private final TranscriptionEngine fasterWhisperEngine;
     private final AudioWindowService audioWindowService;
     private final UrlDownloader urlDownloader;
     private final RecommendationService recommendationService;
 
     private static final int DEFAULT_TOP_N = 6;
 
-    public DetectWorkflow(MediaRepository mediaRepo, TranscriptRepository transcriptRepo, SegmentRepository segmentRepo, StorageService storage, DetectionEngine detection, FasterWhisperClient fastWhisperClient, AudioWindowService audioWindowService, UrlDownloader urlDownloader, RecommendationService recommendationService) {
+    public DetectWorkflow(MediaRepository mediaRepo, TranscriptRepository transcriptRepo, SegmentRepository segmentRepo, StorageService storage, DetectionEngine detection, TranscriptionService transcriptService, @Qualifier("gptDiarizeEngine") TranscriptionEngine gptDiarizeEngine, @Qualifier("fasterWhisperEngine") TranscriptionEngine fasterWhisperEngine, AudioWindowService audioWindowService, UrlDownloader urlDownloader, RecommendationService recommendationService) {
         this.mediaRepo = mediaRepo;
         this.transcriptRepo = transcriptRepo;
         this.segmentRepo = segmentRepo;
         this.storage = storage;
         this.detection = detection;
-        this.fastWhisperClient = fastWhisperClient;
+        this.transcriptService = transcriptService;
+        this.gptDiarizeEngine = gptDiarizeEngine;
+        this.fasterWhisperEngine = fasterWhisperEngine;
         this.audioWindowService = audioWindowService;
         this.urlDownloader = urlDownloader;
         this.recommendationService = recommendationService;
@@ -67,15 +71,16 @@ public class DetectWorkflow {
             // --- No TX: IO / transcript ---
             String lang = optStr(payload, "lang");
             String provider = optStr(payload, "provider");
-            LOGGER.debug("DW.run about to resolveOrCreateTranscript lang={} provider={}", lang, provider);
+            boolean isMulti = media.isMultiSpeakerEffective();
+            LOGGER.info("DETECT selectEngine mediaId={} speakerMode={} isMultiSpeakerEffective={} jobProvider={}", media.getId(), media.getSpeakerMode(), isMulti, provider);
 
-            Transcript tr = resolveOrCreateTranscript(media, lang, provider); // zonder TX
+            Transcript tr = resolveOrCreateTranscript(media, lang, provider, isMulti); // zonder TX
             LOGGER.info("DETECT words={} media={}",
                     (tr!=null && tr.getWords()!=null && tr.getWords().has("items")) ? tr.getWords().get("items").size() : -1,
                     media.getId());
 
             Path srcPath = requireRaw(media);
-            DetectionParams params = buildParams(payload).withSpeakerTurnsEnabled(media.isMultiSpeakerEffective());
+            DetectionParams params = buildParams(payload).withSpeakerTurnsEnabled(isMulti);
             LOGGER.debug("DETECT params speakerTurnsEnabled={} media={}", params.speakerTurnsEnabled(), media.getId());
             var detected = detection.detect(srcPath, tr, params);
 
@@ -105,63 +110,47 @@ public class DetectWorkflow {
         return media;
     }
 
-    protected Transcript resolveOrCreateTranscript(Media media, String lang, String provider) throws Exception {
-        LOGGER.debug("DW.resolveOrCreateTranscript media={} lang={} provider={}", media.getId(), lang, provider);
+    protected Transcript resolveOrCreateTranscript(Media media, String lang, String provider, boolean isMultiSpeaker) throws Exception {
+        LOGGER.debug("DW.resolveOrCreateTranscript media={} lang={} provider={} isMulti={}", media.getId(), lang, provider, isMultiSpeaker);
 
-        // 1) Als er al een transcript is: return (laatste = ok voor detect)
         Transcript existing = transcriptRepo.findTopByMediaOrderByCreatedAtDesc(media).orElse(null);
         if (existing != null) {
             LOGGER.debug("DW transcript exists id={} createdAt={}", existing.getId(), existing.getCreatedAt());
             return existing;
         }
 
-        // 2) RAW garanderen (download bij source=url)
         Path raw = requireRaw(media);
         long size = java.nio.file.Files.size(raw);
-        LOGGER.info("FW START media={} key={} size={}B", media.getId(), media.getObjectKey(), size);
 
-        // Provider-keuze (nu alleen fw; breid later uit met gpt engine)
-        String chosen = (provider == null || provider.isBlank()) ? "fw" : provider.trim().toLowerCase(Locale.ROOT);
-        if (!chosen.equals("fw")) {
-            LOGGER.warn("Provider '{}' nog niet geimplementeerd in DetectWorkflow; fallback naar 'fw'", chosen);
-            chosen = "fw";
+        TranscriptionEngine engine = isMultiSpeaker ? gptDiarizeEngine : fasterWhisperEngine;
+        String selectedEngine = isMultiSpeaker ? "GPT_DIARIZE" : "FASTER_WHISPER";
+        LOGGER.info("DETECT TRANSCRIBE selectEngine={} mediaId={} speakerMode={} jobProvider={} size={}B", selectedEngine, media.getId(), media.getSpeakerMode(), provider, size);
+
+        TranscriptionEngine.Request req = new TranscriptionEngine.Request(media.getId(), media.getObjectKey(), null);
+        TranscriptionEngine.Result res;
+        try {
+            res = engine.transcribe(req);
+        } catch (Exception ex) {
+            if (isMultiSpeaker) {
+                LOGGER.warn("DETECT TRANSCRIBE primary GPT diarize failed mediaId={} reason={} – fallback to FasterWhisper", media.getId(), ex.toString());
+                res = fasterWhisperEngine.transcribe(req);
+                selectedEngine = "FASTER_WHISPER";
+            } else {
+                throw ex;
+            }
         }
 
-        long t0 = System.nanoTime();
-        FwVerboseResponse fw;
+        UUID transcriptId = transcriptService.upsert(media.getId(), res);
+        Transcript saved = transcriptRepo.findById(transcriptId).orElseThrow();
         try {
-            fw = fastWhisperClient.transcribeFile(raw, true); // word timestamps
-        } catch (TimeoutException te) {
-            LOGGER.warn("FW TIMEOUT media={} after {} ms", media.getId(), (System.nanoTime()-t0)/1_000_000);
-            throw te;
-        }
-        long dtMs = (System.nanoTime()-t0)/1_000_000;
-        int segCount = (fw != null && fw.segments()!=null) ? fw.segments().size() : -1;
-        LOGGER.info("FW DONE  media={} in {} ms, segments={}", media.getId(), dtMs, segCount);
-
-        // 4) Transcript entity vullen
-        Transcript t = new Transcript();
-        t.setMedia(media);
-        t.setLang(  fw != null && fw.language()!=null ? fw.language().toLowerCase(Locale.ROOT) : defaultLang(lang));
-        t.setProvider("fw");
-        t.setText( fw != null && fw.text()!=null ? fw.text().strip() : "" );
-        t.setWords( toWordsJson(fw) ); // JsonNode
-
-        t = transcriptRepo.save(t);
-
-        // Korte sanity-log (hoeveel woorden parsed door WordsParser)
-        try {
-            var words = WordsParser.extract(t);
-            LOGGER.info("TRANSCRIPT SAVED media={} id={} words={}", media.getId(), t.getId(), words.size());
+            var words = WordsParser.extract(saved);
+            LOGGER.info("TRANSCRIPT SAVED media={} id={} words={} engine={}", media.getId(), saved.getId(), words.size(), selectedEngine);
         } catch (Exception parseEx) {
-            LOGGER.warn("WordsParser failed media={} id={} err={}", media.getId(), t.getId(), parseEx.toString());
+            LOGGER.warn("WordsParser failed media={} id={} engine={} err={}", media.getId(), saved.getId(), selectedEngine, parseEx.toString());
         }
-
-        return t;
+        LOGGER.info("DETECT TRANSCRIBE DONE mediaId={} engine={}", media.getId(), selectedEngine);
+        return saved;
     }
-
-
-
 
 
     private String defaultLang(String hint) {

--- a/src/main/java/com/example/clipbot_backend/service/DetectionService.java
+++ b/src/main/java/com/example/clipbot_backend/service/DetectionService.java
@@ -128,7 +128,8 @@ public class DetectionService {
                     p.minDurationMs(), p.maxDurationMs(), p.maxCandidates(),
                     p.silenceNoiseDb(), p.silenceMinDurSec(), p.snapThresholdMs(),
                     p.targetLenSec(), p.lenSigmaSec(),
-                    opts.sceneThreshold(), p.snapSceneMs(), p.sceneAlignBonus()
+                    opts.sceneThreshold(), p.snapSceneMs(), p.sceneAlignBonus(),
+                    p.speakerTurnsEnabled()
             );
         }
         return p;

--- a/src/main/java/com/example/clipbot_backend/service/Interfaces/MediaService.java
+++ b/src/main/java/com/example/clipbot_backend/service/Interfaces/MediaService.java
@@ -3,6 +3,7 @@ package com.example.clipbot_backend.service.Interfaces;
 import com.example.clipbot_backend.model.Media;
 import com.example.clipbot_backend.util.MediaPlatform;
 import com.example.clipbot_backend.util.MediaStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -14,5 +15,5 @@ public interface MediaService {
     Media get(UUID mediaId);
     void setStatus(UUID mediaId, MediaStatus status);
     void setDuration(UUID mediaId, long durationMs);
-    UUID createMediaFromUrl(UUID ownerId, String externalUrl, MediaPlatform platform, String source, Long durationMs);
+    UUID createMediaFromUrl(UUID ownerId, String externalUrl, MediaPlatform platform, String source, Long durationMs, SpeakerMode speakerMode);
 }

--- a/src/main/java/com/example/clipbot_backend/service/MediaService.java
+++ b/src/main/java/com/example/clipbot_backend/service/MediaService.java
@@ -6,6 +6,7 @@ import com.example.clipbot_backend.dto.media.CreateFromUrlResponse;
 import com.example.clipbot_backend.repository.MediaRepository;
 import com.example.clipbot_backend.util.MediaPlatform;
 import com.example.clipbot_backend.util.MediaStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
 import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -79,7 +80,8 @@ public class MediaService  {
             MediaPlatform platform,
             String source,
             Long durationMs,
-            String objectKeyOverride // ← gebruik dit als caller er eentje meegeeft
+            String objectKeyOverride, // ← gebruik dit als caller er eentje meegeeft
+            SpeakerMode speakerMode
     ) {
         var owner = accountService.getByIdOrThrow(ownerId);
 
@@ -97,6 +99,7 @@ public class MediaService  {
         media.setPlatform(platform != null ? platform.id() : null);
         media.setSource(normalizedSource);
         media.setStatus(MediaStatus.DOWNLOADING);
+        media.setSpeakerMode(speakerMode == null ? SpeakerMode.SINGLE : speakerMode);
         // Status die in je CHECK-constraint toegestaan is
         if (durationMs != null && durationMs > 0) media.setDurationMs(durationMs);
 
@@ -113,7 +116,7 @@ public class MediaService  {
     }
 
     public CreateFromUrlResponse createFromUrl(UUID ownerId, String url, String source) {
-        UUID mediaId = createMediaFromUrl(ownerId, url, MediaPlatform.OTHER, source, null, null);
+        UUID mediaId = createMediaFromUrl(ownerId, url, MediaPlatform.OTHER, source, null, null, SpeakerMode.SINGLE);
         return new CreateFromUrlResponse(mediaId);
     }
 

--- a/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
+++ b/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
@@ -18,6 +18,7 @@ import com.example.clipbot_backend.service.metadata.MetadataService;
 import com.example.clipbot_backend.service.thumbnail.ThumbnailService;
 import com.example.clipbot_backend.util.MediaPlatform;
 import com.example.clipbot_backend.util.OrchestrationStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
 import com.example.clipbot_backend.util.ThumbnailSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;

--- a/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
+++ b/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
@@ -306,7 +306,10 @@ public class OneClickOrchestrator {
     }
 
     private ThumbnailSource applyThumbnailIfPresent(UUID projectId, MetadataResult metadata) {
-        if (metadata != null && metadata.platform() == MediaPlatform.YOUTUBE && metadata.thumbnail() != null) {
+        if (metadata != null && metadata.platform() == MediaPlatform.YOUTUBE) {
+            return ThumbnailSource.DEFERRED;
+        }
+        if (metadata != null && metadata.thumbnail() != null) {
             projectService.patch(projectId, ProjectPatch.builder().thumbnailUrl(metadata.thumbnail()).build());
             return ThumbnailSource.YOUTUBE;
         }

--- a/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
+++ b/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
@@ -13,7 +13,7 @@ import com.example.clipbot_backend.repository.MediaRepository;
 import com.example.clipbot_backend.repository.OneClickOrchestrationRepository;
 import com.example.clipbot_backend.repository.SegmentRepository;
 import com.example.clipbot_backend.repository.TranscriptRepository;
-import com.example.clipbot_backend.service.Interfaces.JobService;
+import com.example.clipbot_backend.service.JobService;
 import com.example.clipbot_backend.service.metadata.MetadataResult;
 import com.example.clipbot_backend.service.metadata.MetadataService;
 import com.example.clipbot_backend.service.thumbnail.ThumbnailService;

--- a/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
+++ b/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
@@ -223,7 +223,8 @@ public class OneClickOrchestrator {
                         platform,
                         "ingest",
                         durationMs,
-                        null)
+                        null,
+                        SpeakerMode.SINGLE)
         );
         return created.mediaId();
     }

--- a/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
+++ b/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
@@ -255,9 +255,9 @@ public class OneClickOrchestrator {
 
         String lang = options.normalizedLang();
         String provider = options.normalizedProvider();
+        boolean isMulti = media.isMultiSpeakerEffective();
         if (provider == null) {
-            Long durationMs = media.getDurationMs();
-            provider = (durationMs != null && durationMs > 25 * 60 * 1000L) ? "openai-diarize" : "fasterwhisper";
+            provider = isMulti ? "openai-diarize" : "fasterwhisper";
         }
         Double sceneThreshold = options.normalizedSceneThreshold();
         Integer requested = options.resolvedTopN(DEFAULT_TOP_N);

--- a/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
+++ b/src/main/java/com/example/clipbot_backend/service/OneClickOrchestrator.java
@@ -256,9 +256,7 @@ public class OneClickOrchestrator {
         String lang = options.normalizedLang();
         String provider = options.normalizedProvider();
         boolean isMulti = media.isMultiSpeakerEffective();
-        if (provider == null) {
-            provider = isMulti ? "openai-diarize" : "fasterwhisper";
-        }
+        String resolvedProvider = provider == null ? (isMulti ? "openai-diarize" : "fasterwhisper") : provider;
         Double sceneThreshold = options.normalizedSceneThreshold();
         Integer requested = options.resolvedTopN(DEFAULT_TOP_N);
         Boolean enqueueRender = options.shouldEnqueueRender(true);
@@ -266,7 +264,7 @@ public class OneClickOrchestrator {
 
         Map<String, Object> detectPayload = new LinkedHashMap<>();
         detectPayload.computeIfAbsent("lang", k -> normalizedLang);
-        detectPayload.computeIfAbsent("provider", k -> provider);
+        detectPayload.computeIfAbsent("provider", k -> resolvedProvider);
         if (sceneThreshold != null) detectPayload.put("sceneThreshold", sceneThreshold);
         if (requested != null) detectPayload.put("topN", requested);
         if (enqueueRender != null) detectPayload.put("enqueueRender", enqueueRender);
@@ -277,7 +275,7 @@ public class OneClickOrchestrator {
             jobId = detectionService.enqueueDetect(
                     mediaId,
                     normalizedLang,
-                    provider,
+                    resolvedProvider,
                     sceneThreshold,
                     requested,
                     enqueueRender
@@ -286,7 +284,7 @@ public class OneClickOrchestrator {
             jobId = jobService.enqueue(mediaId, JobType.TRANSCRIBE, Map.of("detectPayload", detectPayload));
         }
 
-        return new DetectOutcome(new OneClickJob(jobId, "ENQUEUED"), normalizedLang, provider, requested, enqueueRender);
+        return new DetectOutcome(new OneClickJob(jobId, "ENQUEUED"), normalizedLang, resolvedProvider, requested, enqueueRender);
     }
 
     private OneClickRecommendation enqueueRecommendationsIfReady(UUID mediaId, String ownerExternalSubject, OneClickRequest.Options options) {

--- a/src/main/java/com/example/clipbot_backend/service/UploadService.java
+++ b/src/main/java/com/example/clipbot_backend/service/UploadService.java
@@ -16,6 +16,7 @@ import com.example.clipbot_backend.util.AssetKind;
 import com.example.clipbot_backend.util.JobStatus;
 import com.example.clipbot_backend.util.JobType;
 import com.example.clipbot_backend.util.MediaStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,7 +64,8 @@ public class UploadService {
     public UploadCompleteResponse uploadLocal(String ownerExternalSubject,
                                               String objectKey,
                                               MultipartFile file,
-                                              String sourceLabel) throws Exception {
+                                              String sourceLabel,
+                                              Boolean podcastOrInterview) throws Exception {
         if (file == null || file.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "FILE_EMPTY");
         }
@@ -80,6 +82,12 @@ public class UploadService {
 
         var media = new Media(owner, objectKey);
         media.setSource(sourceLabel == null ? "upload" : sourceLabel.trim().toLowerCase());
+        SpeakerMode speakerMode = Boolean.TRUE.equals(podcastOrInterview) ? SpeakerMode.MULTI : SpeakerMode.SINGLE;
+        if (SpeakerMode.MULTI.equals(speakerMode)) {
+            org.slf4j.LoggerFactory.getLogger(UploadService.class)
+                    .info("INGEST upload podcastOrInterview=true speakerMode=MULTI owner={} objectKey={}", ownerExternalSubject, objectKey);
+        }
+        media.setSpeakerMode(speakerMode);
         media.setStatus(MediaStatus.REGISTERED);
         mediarepo.saveAndFlush(media);
         Path tmp = null;

--- a/src/main/java/com/example/clipbot_backend/service/UrlDownloader.java
+++ b/src/main/java/com/example/clipbot_backend/service/UrlDownloader.java
@@ -1,10 +1,10 @@
 package com.example.clipbot_backend.service;
 
 import com.example.clipbot_backend.service.Interfaces.StorageService;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,15 +12,20 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.StringJoiner;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class UrlDownloader {
+    private static final Logger log = LoggerFactory.getLogger(UrlDownloader.class);
+    private static final long YTDLP_TIMEOUT_MINUTES = 15;
+    private static final int LOG_SNIPPET_MAX = 4_000;
     private final StorageService storage;
-    private final String ytdlp
-            ;
+    private final String ytdlp;
+    private final String ytdlpCookiesFile;
     // HTTP download settings
     private final Integer httpTimeoutMs;
     private final String httpUserAgent;
@@ -29,17 +34,18 @@ public class UrlDownloader {
 
     public UrlDownloader(StorageService storage,
                          @Value("${downloader.ytdlp.bin:yt-dlp}") String ytdlp,
-                         @Value("${downloader.http.timeoutSeconds:120}")Integer httpTimeoutMs,
-                         @Value("${downloader.http.userAgent:Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome Safari}")String httpUserAgent,
+                         @Value("${downloader.http.timeoutSeconds:120}") Integer httpTimeoutMs,
+                         @Value("${downloader.http.userAgent:Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome Safari}") String httpUserAgent,
                          @Value("${downloader.http.maxRedirects:5}") Integer maxRedirects,
-                         @Value("${ffmpeg.binary:ffmpeg}") String ffmpegBin)
-    {
+                         @Value("${ffmpeg.binary:ffmpeg}") String ffmpegBin,
+                         @Value("${YTDLP_COOKIES_FILE:#{null}}") String ytdlpCookiesFile) {
         this.storage = storage;
         this.ytdlp = ytdlp;
         this.httpTimeoutMs = httpTimeoutMs * 1000;
         this.httpUserAgent = httpUserAgent;
         this.maxRedirects = maxRedirects;
         this.ffmpegBin = ffmpegBin;
+        this.ytdlpCookiesFile = ytdlpCookiesFile;
     }
 
     /** Downloadt naar RAW exact op objectKey en retourneert dat pad */
@@ -87,8 +93,7 @@ public class UrlDownloader {
     }
     private void downloadYoutubeMp4(String url, Path mp4Target) throws Exception {
         Files.createDirectories(mp4Target.getParent());
-        // Kies h264 + beste audio, ≤1080p; forceer mp4 container.
-        ProcessResult result = runProcess(List.of(
+        List<String> cmd = new ArrayList<>(List.of(
                 ytdlp,
                 "--no-progress", "--newline",
                 "-S", "res:1080,codec:h264",
@@ -99,9 +104,23 @@ public class UrlDownloader {
                 url
         ));
 
-        if (result.code() != 0 || !Files.exists(mp4Target)) {
-            throw new IllegalStateException("yt-dlp exit=" + result.code() + " output missing: " + mp4Target + " log=" + truncateLog(result.output()));
+        maybeAddCookies(cmd);
+
+        ProcessResult result = runProcess(cmd, YTDLP_TIMEOUT_MINUTES);
+
+        if (result.timedOut()) {
+            throw new IllegalStateException("yt-dlp timeout after " + YTDLP_TIMEOUT_MINUTES + "m for " + url + " log=" + truncateLog(result.output()));
         }
+
+        if (result.code() != 0 || !Files.exists(mp4Target)) {
+            String output = result.output();
+            if (isAuthWall(output)) {
+                throw new IllegalStateException("YouTube download requires authentication/cookies for " + url + " log=" + truncateLog(output));
+            }
+            throw new IllegalStateException("yt-dlp exit=" + result.code() + " output missing: " + mp4Target + " log=" + truncateLog(output));
+        }
+
+        log.info("yt-dlp download OK target={} url={}", mp4Target, url);
     }
     private void extractAudioM4a(Path mp4, Path m4a) throws Exception {
         Files.createDirectories(m4a.getParent());
@@ -147,32 +166,64 @@ public class UrlDownloader {
         return p.waitFor();
     }
 
-    protected ProcessResult runProcess(List<String> cmd) throws IOException, InterruptedException {
+    protected ProcessResult runProcess(List<String> cmd, long timeoutMinutes) throws IOException, InterruptedException {
         Process p = new ProcessBuilder(cmd).redirectErrorStream(true).start();
         StringJoiner joiner = new StringJoiner(System.lineSeparator());
-        try (var reader = new java.io.BufferedReader(new java.io.InputStreamReader(p.getInputStream()))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                System.out.println(line);
-                joiner.add(line);
+        Thread reader = new Thread(() -> {
+            try (var buffered = new java.io.BufferedReader(new java.io.InputStreamReader(p.getInputStream()))) {
+                String line;
+                while ((line = buffered.readLine()) != null) {
+                    joiner.add(line);
+                }
+            } catch (IOException ignored) {
+                // Process failure is handled by exit code/timeout; output collected so far is enough.
             }
+        });
+        reader.start();
+
+        boolean finished = p.waitFor(timeoutMinutes, TimeUnit.MINUTES);
+        if (!finished) {
+            p.destroyForcibly();
         }
-        int code = p.waitFor();
-        return new ProcessResult(code, joiner.toString());
+        reader.join();
+        int code = finished ? p.exitValue() : -1;
+        return new ProcessResult(code, joiner.toString(), !finished);
     }
 
     private String truncateLog(String output) {
-        final int max = 800;
-        if (output == null) {
+        if (output == null || output.isBlank()) {
             return "<no output>";
         }
-        if (output.length() <= max) {
+        if (output.length() <= LOG_SNIPPET_MAX) {
             return output;
         }
-        return output.substring(0, max) + "...";
+        return output.substring(0, LOG_SNIPPET_MAX) + "...";
     }
 
-    protected record ProcessResult(int code, String output) { }
+    private boolean isAuthWall(String output) {
+        if (output == null) {
+            return false;
+        }
+        String normalized = output.toLowerCase(Locale.ROOT).replace('\u2019', '\'');
+        return normalized.contains("sign in to confirm you're not a bot")
+                || normalized.contains("--cookies-from-browser")
+                || normalized.contains("use --cookies");
+    }
+
+    private void maybeAddCookies(List<String> cmd) {
+        if (ytdlpCookiesFile == null || ytdlpCookiesFile.isBlank()) {
+            return;
+        }
+        Path cookiesPath = Path.of(ytdlpCookiesFile).toAbsolutePath();
+        if (Files.exists(cookiesPath)) {
+            cmd.add("--cookies");
+            cmd.add(cookiesPath.toString());
+        } else {
+            log.warn("yt-dlp cookies file configured but missing path={}", cookiesPath);
+        }
+    }
+
+    protected record ProcessResult(int code, String output, boolean timedOut) { }
 
 
     private void downloadWithHttp(String url, Path target) throws Exception {

--- a/src/main/java/com/example/clipbot_backend/service/WorkerService.java
+++ b/src/main/java/com/example/clipbot_backend/service/WorkerService.java
@@ -126,7 +126,7 @@ public class WorkerService {
     }
 
 @Transactional
-void handleTranscribe(Job job) {
+    void handleTranscribe(Job job) {
     LOGGER.debug("TRANSCRIBE enter jobId={} mediaId={}", job.getId(), job.getMedia()!=null?job.getMedia().getId():null); // 👈
     Objects.requireNonNull(job, "job");
     final UUID mediaId = job.getMedia() != null ? job.getMedia().getId() : null;
@@ -141,7 +141,7 @@ void handleTranscribe(Job job) {
         // 0) Idempotent: als transcript al bestaat → overslaan en direct DETECT enqueuen
         if (transcriptService.existsAnyFor(mediaId)) {
             jobService.markDone(job.getId(), Map.of("skipped", "already_transcribed"));
-            jobService.enqueue(mediaId, DETECT, Map.of());
+            jobService.enqueue(mediaId, DETECT, forwardedDetectPayload(job, null));
             return;
         }
 
@@ -214,10 +214,7 @@ void handleTranscribe(Job job) {
                 "provider", res.provider(),
                 "durationMs", (System.nanoTime() - t0) / 1_000_000
         ));
-        jobService.enqueue(media.getId(), DETECT, Map.of(
-                "lang", res.lang(),
-                "provider", res.provider()
-        ));
+        jobService.enqueue(media.getId(), DETECT, forwardedDetectPayload(job, res));
 
         LOGGER.info("TRANSCRIBE {} OK in {} ms (lang={}, provider={})",
                 mediaId, (System.nanoTime() - t0) / 1_000_000, res.lang(), res.provider());
@@ -236,6 +233,21 @@ void handleTranscribe(Job job) {
     }
 
 }
+
+    private Map<String, Object> forwardedDetectPayload(Job job, TranscriptionEngine.Result res) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        if (job != null && job.getPayload() != null) {
+            Object detect = job.getPayload().get("detectPayload");
+            if (detect instanceof Map<?, ?> detectMap) {
+                detectMap.forEach((k, v) -> payload.put(String.valueOf(k), v));
+            }
+        }
+        if (res != null) {
+            payload.put("lang", res.lang());
+            payload.put("provider", res.provider());
+        }
+        return payload.isEmpty() ? Map.of() : payload;
+    }
     private String stackTop(Throwable ex) {
         var sw = new java.io.StringWriter();
         ex.printStackTrace(new java.io.PrintWriter(sw));

--- a/src/main/java/com/example/clipbot_backend/service/thumbnail/ThumbnailService.java
+++ b/src/main/java/com/example/clipbot_backend/service/thumbnail/ThumbnailService.java
@@ -1,12 +1,28 @@
 package com.example.clipbot_backend.service.thumbnail;
 
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Asset;
+import com.example.clipbot_backend.model.Media;
 import com.example.clipbot_backend.model.Project;
+import com.example.clipbot_backend.model.ProjectMediaLink;
+import com.example.clipbot_backend.repository.AccountRepository;
+import com.example.clipbot_backend.repository.AssetRepository;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.repository.ProjectMediaRepository;
 import com.example.clipbot_backend.repository.ProjectRepository;
+import com.example.clipbot_backend.service.Interfaces.StorageService;
+import com.example.clipbot_backend.util.AssetKind;
+import org.springframework.beans.factory.annotation.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -17,11 +33,35 @@ import java.util.concurrent.ConcurrentHashMap;
 @Service
 public class ThumbnailService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ThumbnailService.class);
+    private static final String DEFAULT_THUMB_PATTERN = "media/thumbs/%s.jpg";
+    private static final double MIN_THUMB_SEC = 1.0;
+    private static final double DEFAULT_THUMB_SEC = 5.0;
+    private static final double PCT_THUMB_FRACTION = 0.04;
+    private static final double MIN_PCT_SEC = 3.0;
+
     private final ProjectRepository projectRepository;
+    private final ProjectMediaRepository projectMediaRepository;
+    private final AssetRepository assetRepository;
+    private final MediaRepository mediaRepository;
+    private final AccountRepository accountRepository;
+    private final StorageService storageService;
+    private final String ffmpegBin;
     private final Set<UUID> pendingFallbacks = ConcurrentHashMap.newKeySet();
 
-    public ThumbnailService(ProjectRepository projectRepository) {
+    public ThumbnailService(ProjectRepository projectRepository,
+                            ProjectMediaRepository projectMediaRepository,
+                            AssetRepository assetRepository,
+                            MediaRepository mediaRepository,
+                            AccountRepository accountRepository,
+                            StorageService storageService,
+                            @Value("${ffmpeg.binary:ffmpeg}") String ffmpegBin) {
         this.projectRepository = projectRepository;
+        this.projectMediaRepository = projectMediaRepository;
+        this.assetRepository = assetRepository;
+        this.mediaRepository = mediaRepository;
+        this.accountRepository = accountRepository;
+        this.storageService = storageService;
+        this.ffmpegBin = ffmpegBin;
     }
 
     /**
@@ -59,5 +99,115 @@ public class ThumbnailService {
         projectRepository.save(project);
         pendingFallbacks.remove(project.getId());
         LOGGER.info("ThumbnailService fallback applied projectId={} thumbnail={}", project.getId(), thumbnailUrl);
+    }
+
+    /**
+     * Extracts a thumbnail from the downloaded source and assigns it to related projects/media.
+     * Runs only when the source file is present locally.
+     */
+    public void extractFromLocalMedia(Media media, Path localSource) {
+        if (media == null || localSource == null) {
+            return;
+        }
+        if (!Files.exists(localSource)) {
+            LOGGER.debug("Thumbnail extract skipped; file missing mediaId={} path={}", media.getId(), localSource);
+            return;
+        }
+        if (!looksLikeVideo(localSource)) {
+            LOGGER.debug("Thumbnail extract skipped; non-video source mediaId={} path={}", media.getId(), localSource);
+            return;
+        }
+
+        String thumbKey = buildThumbKey(media.getId());
+        if (storageService.existsInOut(thumbKey)) {
+            persistThumbnailReferences(media.getId(), media.getOwner().getId(), thumbKey, resolveSize(thumbKey));
+            return;
+        }
+
+        LOGGER.info("Thumbnail extract scheduled mediaId={} file={}", media.getId(), localSource);
+        Path tempOutput = null;
+        try {
+            tempOutput = Files.createTempFile("thumb-", ".jpg");
+            double seekSec = computeSeekSeconds(media);
+            List<String> cmd = List.of(
+                    ffmpegBin, "-y",
+                    "-ss", String.format(java.util.Locale.ROOT, "%.3f", seekSec),
+                    "-i", localSource.toAbsolutePath().toString(),
+                    "-frames:v", "1",
+                    "-q:v", "2",
+                    tempOutput.toAbsolutePath().toString()
+            );
+            LOGGER.info("Thumbnail extract started mediaId={} seekSec={} cmd={} output={} ", media.getId(), seekSec, cmd, tempOutput);
+            new ProcessBuilder(cmd).redirectErrorStream(true).start().waitFor();
+
+            if (!Files.exists(tempOutput) || Files.size(tempOutput) <= 0) {
+                LOGGER.warn("Thumbnail extract failed (empty output) mediaId={} file={}", media.getId(), localSource);
+                return;
+            }
+
+            storageService.uploadToOut(tempOutput, thumbKey);
+            long size = Files.size(tempOutput);
+            LOGGER.info("Thumbnail extract completed mediaId={} thumbKey={} size={}B", media.getId(), thumbKey, size);
+            persistThumbnailReferences(media.getId(), media.getOwner().getId(), thumbKey, size);
+        } catch (Exception ex) {
+            LOGGER.warn("Thumbnail extract failed mediaId={} path={} err={}", media.getId(), localSource, ex.toString());
+        } finally {
+            if (tempOutput != null) {
+                try {
+                    Files.deleteIfExists(tempOutput);
+                } catch (Exception ignore) {
+                }
+            }
+        }
+    }
+
+    private long resolveSize(String thumbKey) {
+        try {
+            return Files.size(storageService.resolveOut(thumbKey));
+        } catch (Exception ex) {
+            return 0;
+        }
+    }
+
+    private boolean looksLikeVideo(Path source) {
+        String name = source.getFileName().toString().toLowerCase(java.util.Locale.ROOT);
+        return name.endsWith(".mp4") || name.endsWith(".mov") || name.endsWith(".mkv") || name.endsWith(".webm") || name.endsWith(".m4v");
+    }
+
+    private String buildThumbKey(UUID mediaId) {
+        return String.format(DEFAULT_THUMB_PATTERN, mediaId);
+    }
+
+    private double computeSeekSeconds(Media media) {
+        if (media.getDurationMs() == null || media.getDurationMs() <= 0) {
+            return DEFAULT_THUMB_SEC;
+        }
+        double durSec = media.getDurationMs() / 1000.0;
+        double pct = durSec * PCT_THUMB_FRACTION;
+        double clamped = Math.max(MIN_PCT_SEC, Math.min(pct, Math.max(MIN_THUMB_SEC, durSec - 1.0)));
+        return Math.max(MIN_THUMB_SEC, clamped);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    protected void persistThumbnailReferences(UUID mediaId, UUID ownerId, String thumbKey, long size) {
+        Media mediaRef = mediaRepository.getReferenceById(mediaId);
+        Account ownerRef = accountRepository.getReferenceById(ownerId);
+
+        Asset asset = new Asset(ownerRef, AssetKind.THUMBNAIL, thumbKey, size <= 0 ? 1 : size);
+        asset.setRelatedMedia(mediaRef);
+        assetRepository.save(asset);
+
+        List<ProjectMediaLink> links = projectMediaRepository.findByMedia(mediaRef);
+        List<Project> toSave = new ArrayList<>(links.size());
+        for (ProjectMediaLink link : links) {
+            Project project = link.getProject();
+            if (project.getThumbnailUrl() == null || project.getThumbnailUrl().isBlank()) {
+                project.setThumbnailUrl(thumbKey);
+                toSave.add(project);
+            }
+        }
+        if (!toSave.isEmpty()) {
+            projectRepository.saveAll(toSave);
+        }
     }
 }

--- a/src/main/java/com/example/clipbot_backend/util/HeuristicScorer.java
+++ b/src/main/java/com/example/clipbot_backend/util/HeuristicScorer.java
@@ -1,11 +1,14 @@
 package com.example.clipbot_backend.util;
 
 import com.example.clipbot_backend.dto.SentenceSpan;
+import com.example.clipbot_backend.dto.SpeakerTurn;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HeuristicScorer {
     public record Result(
@@ -13,7 +16,11 @@ public class HeuristicScorer {
             double lenScore,
             boolean hasHook,
             boolean hasPayoff,
-            double boundaryBonus
+            double boundaryBonus,
+            double speakerBoundaryBonus,
+            double speakerTurnBonus,
+            double speakerMidPenalty,
+            boolean speakerHeuristicsApplied
     ) {
         public Map<String, Object> toMeta() {
             Map<String, Object> m = new LinkedHashMap<>();
@@ -22,6 +29,10 @@ public class HeuristicScorer {
             m.put("hasHook", hasHook);
             m.put("hasPayoff", hasPayoff);
             m.put("boundaryBonus", boundaryBonus);
+            m.put("speakerBoundaryBonus", speakerBoundaryBonus);
+            m.put("speakerTurnBonus", speakerTurnBonus);
+            m.put("speakerMidPenalty", speakerMidPenalty);
+            m.put("speakerHeuristicsApplied", speakerHeuristicsApplied);
             return m;
         }
     }
@@ -38,14 +49,20 @@ public class HeuristicScorer {
     private static final double LEN_FLOOR = 0.15;   // min score voor lengte
     private static final double MIN_SIGMA = 6.0;    // voorkom te scherpe bel
     private static final double BASE_BOUNDARY = 0.05;
+    private static final long TURN_WINDOW_MS = 900;
+    private static final long MID_TURN_PENALTY_MS = 1_600;
+    private static final double TURN_COUNT_BONUS = 0.06;
+    private static final double MID_TURN_PENALTY = 0.08;
 
-    public Result scoreWindow(List<SentenceSpan> sents, double targetLenSec, double sigmaSec) {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HeuristicScorer.class);
+
+    public Result scoreWindow(List<SentenceSpan> sents, double targetLenSec, double sigmaSec, SpeakerContext speakerContext, long startMsOverride, long endMsOverride) {
         if (sents == null || sents.isEmpty()) {
-            return new Result(0, 0, false, false, 0);
+            return new Result(0, 0, false, false, 0, 0, 0, 0, false);
         }
 
-        long startMs = sents.getFirst().startMs();
-        long endMs   = sents.getLast().endMs();
+        long startMs = startMsOverride;
+        long endMs   = endMsOverride;
         double lenSec = Math.max(0.001, (endMs - startMs) / 1000.0);
 
         // 1) Lengte-score – tolerant
@@ -64,15 +81,83 @@ public class HeuristicScorer {
         boolean startsNeat = Character.isLetterOrDigit(trimmed.isEmpty() ? ' ' : trimmed.charAt(0));
         double boundaryBonus = BASE_BOUNDARY + (endsNeat ? 0.06 : 0) + (startsNeat ? 0.04 : 0);
 
+        // 3b) Speaker-aware heuristieken (alleen wanneer aangezet)
+        double speakerBoundaryBonus = 0;
+        double speakerTurnBonus = 0;
+        double speakerMidPenalty = 0;
+        boolean speakerApplied = speakerContext != null && speakerContext.enabled() && speakerContext.hasTurns();
+        if (speakerApplied) {
+            long nearestStart = speakerContext.distanceToBoundary(startMs);
+            long nearestEnd = speakerContext.distanceToBoundary(endMs);
+            if (nearestStart >= 0 && nearestStart <= TURN_WINDOW_MS) {
+                speakerBoundaryBonus += 0.06 * (1.0 - (nearestStart / (double) TURN_WINDOW_MS));
+            } else if (nearestStart > MID_TURN_PENALTY_MS && !startsNeat) {
+                speakerMidPenalty += MID_TURN_PENALTY * 0.5;
+            }
+            if (nearestEnd >= 0 && nearestEnd <= TURN_WINDOW_MS) {
+                speakerBoundaryBonus += 0.06 * (1.0 - (nearestEnd / (double) TURN_WINDOW_MS));
+            } else if (nearestEnd > MID_TURN_PENALTY_MS && !endsNeat) {
+                speakerMidPenalty += MID_TURN_PENALTY * 0.5;
+            }
+
+            int turnsInside = speakerContext.countTurnsWithin(startMs, endMs);
+            if (turnsInside >= 2 && turnsInside <= 8) {
+                speakerTurnBonus += TURN_COUNT_BONUS;
+            } else if (turnsInside == 0) {
+                speakerMidPenalty += MID_TURN_PENALTY;
+            } else if (turnsInside > 10) {
+                speakerMidPenalty += MID_TURN_PENALTY * 0.5;
+            }
+        }
+
         // 4) Combineer – geef inhoudelijke termen wel gewicht, maar niet allesbepalend
-        double overall = 0.6 * lenScore
+        double base = 0.6 * lenScore
                 + (hasHook ? 0.12 : 0)
                 + (hasPayoff ? 0.12 : 0)
                 + boundaryBonus;
 
+        double speakerDelta = speakerBoundaryBonus + speakerTurnBonus - speakerMidPenalty;
+        double overall = base + speakerDelta;
+
         // zachte clamp en bodem: we willen nooit exact 0
         overall = Math.max(0.05, Math.min(1.0, overall));
-        return new Result(overall, lenScore, hasHook, hasPayoff, boundaryBonus);
+        if (speakerApplied && LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Speaker scoring applied start={} end={} boundaryBonus={} midPenalty={} turnBonus={} turnsEnabled={}",
+                    startMs, endMs, speakerBoundaryBonus, speakerMidPenalty, speakerTurnBonus, speakerApplied);
+        }
+        return new Result(overall, lenScore, hasHook, hasPayoff, boundaryBonus,
+                speakerBoundaryBonus, speakerTurnBonus, speakerMidPenalty, speakerApplied);
+    }
+
+    public record SpeakerContext(List<SpeakerTurn> turns, boolean enabled) {
+        public boolean hasTurns() { return turns != null && !turns.isEmpty(); }
+
+        public long distanceToBoundary(long timestampMs) {
+            if (!hasTurns()) return -1;
+            long best = Long.MAX_VALUE;
+            for (int i = 1; i < turns.size(); i++) {
+                if (!turns.get(i).speaker().equals(turns.get(i - 1).speaker())) {
+                    long boundary = turns.get(i).startMs();
+                    long dist = Math.abs(timestampMs - boundary);
+                    if (dist < best) best = dist;
+                }
+            }
+            return best == Long.MAX_VALUE ? -1 : best;
+        }
+
+        public int countTurnsWithin(long startMs, long endMs) {
+            if (!hasTurns()) return 0;
+            int turnsCount = 0;
+            SpeakerTurn prev = null;
+            for (SpeakerTurn t : turns) {
+                if (t.endMs() <= startMs || t.startMs() >= endMs) continue;
+                if (prev != null && !prev.speaker().equals(t.speaker())) {
+                    turnsCount++;
+                }
+                prev = t;
+            }
+            return turnsCount;
+        }
     }
 
     // Tolerantere bel: 1 / (1 + ((x-mu)/sigma)^2)

--- a/src/main/resources/db/migration/V33__speaker_mode_default_single.sql
+++ b/src/main/resources/db/migration/V33__speaker_mode_default_single.sql
@@ -1,0 +1,3 @@
+-- Set explicit default to SINGLE and backfill existing rows
+ALTER TABLE media ALTER COLUMN speaker_mode SET DEFAULT 'SINGLE';
+UPDATE media SET speaker_mode = 'SINGLE' WHERE speaker_mode IS NULL OR speaker_mode = 'AUTO';

--- a/src/test/java/com/example/clipbot_backend/controller/DetectControllerTest.java
+++ b/src/test/java/com/example/clipbot_backend/controller/DetectControllerTest.java
@@ -1,0 +1,91 @@
+package com.example.clipbot_backend.controller;
+
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.service.AccountService;
+import com.example.clipbot_backend.service.DetectionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = DetectController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class DetectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AccountService accountService;
+
+    @MockitoBean
+    private DetectionService detectionService;
+
+    @MockitoBean
+    private MediaRepository mediaRepository;
+
+    @Test
+    void enqueueUsesOwnerFetchJoinToAuthorize() throws Exception {
+        UUID mediaId = UUID.randomUUID();
+        String ownerSubject = "demo-user-1";
+
+        Account owner = new Account();
+        owner.setExternalSubject(ownerSubject);
+
+        Media media = new Media();
+        media.setId(mediaId);
+        media.setOwner(owner);
+
+        when(accountService.isAdmin(ownerSubject)).thenReturn(false);
+        when(mediaRepository.findByIdWithOwner(mediaId)).thenReturn(Optional.of(media));
+        when(detectionService.enqueueDetect(eq(mediaId), any(), any(), any())).thenReturn(UUID.randomUUID());
+
+        mockMvc.perform(post("/v1/media/" + mediaId + "/detect")
+                        .param("ownerExternalSubject", ownerSubject)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.mediaId").value(mediaId.toString()))
+                .andExpect(jsonPath("$.status").value("QUEUED"));
+
+        verify(mediaRepository).findByIdWithOwner(mediaId);
+    }
+
+    @Test
+    void enqueueRejectsWhenOwnerMismatch() throws Exception {
+        UUID mediaId = UUID.randomUUID();
+        String ownerSubject = "demo-user-1";
+
+        Account owner = new Account();
+        owner.setExternalSubject("other-user");
+
+        Media media = new Media();
+        media.setId(mediaId);
+        media.setOwner(owner);
+
+        when(accountService.isAdmin(ownerSubject)).thenReturn(false);
+        when(mediaRepository.findByIdWithOwner(mediaId)).thenReturn(Optional.of(media));
+
+        mockMvc.perform(post("/v1/media/" + mediaId + "/detect")
+                        .param("ownerExternalSubject", ownerSubject)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+
+        verify(mediaRepository).findByIdWithOwner(mediaId);
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/controller/MediaControllerTest.java
+++ b/src/test/java/com/example/clipbot_backend/controller/MediaControllerTest.java
@@ -83,4 +83,40 @@ class MediaControllerTest {
         verify(mediaService).createMediaFromUrl(eq(ownerId), eq(url), eq(MediaPlatform.OTHER), eq("url"), any(), any(), any());
         assertThat(mvcResult.getResponse().getContentAsString()).contains("DOWNLOADING");
     }
+
+    @Test
+    void createFromUrlTreatsNonUuidOwnerIdAsExternalSubject() throws Exception {
+        UUID ownerId = UUID.randomUUID();
+        UUID mediaId = UUID.randomUUID();
+        String externalSubject = "demo-user-1";
+        String url = "https://example.com/audio.mp4";
+
+        Account account = mock(Account.class);
+        when(account.getId()).thenReturn(ownerId);
+        when(accountService.getByExternalSubjectOrThrow(externalSubject)).thenReturn(account);
+        when(metadataService.normalizeUrl(url)).thenReturn(url);
+        when(metadataService.detectPlatform(url)).thenReturn(MediaPlatform.OTHER);
+        when(mediaService.createMediaFromUrl(eq(ownerId), eq(url), eq(MediaPlatform.OTHER), eq("url"), any(), any(), any()))
+                .thenReturn(mediaId);
+
+        Media media = new Media();
+        media.setOwner(account);
+        media.setObjectKey("ext/url/abc/source.m4a");
+        when(mediaService.get(mediaId)).thenReturn(media);
+
+        String body = objectMapper.writeValueAsString(Map.of(
+                "ownerId", externalSubject,
+                "url", url
+        ));
+
+        mockMvc.perform(post("/v1/media/from-url")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mediaId").value(mediaId.toString()))
+                .andExpect(jsonPath("$.objectKey").value("ext/url/abc/source.m4a"));
+
+        verify(accountService).getByExternalSubjectOrThrow(externalSubject);
+        verify(mediaService).createMediaFromUrl(eq(ownerId), eq(url), eq(MediaPlatform.OTHER), eq("url"), any(), any(), any());
+    }
 }

--- a/src/test/java/com/example/clipbot_backend/controller/MediaControllerTest.java
+++ b/src/test/java/com/example/clipbot_backend/controller/MediaControllerTest.java
@@ -1,0 +1,86 @@
+package com.example.clipbot_backend.controller;
+
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.service.AccountService;
+import com.example.clipbot_backend.service.MediaService;
+import com.example.clipbot_backend.service.metadata.MetadataService;
+import com.example.clipbot_backend.util.MediaPlatform;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = MediaController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MediaControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private MediaService mediaService;
+
+    @MockitoBean
+    private MetadataService metadataService;
+
+    @MockitoBean
+    private AccountService accountService;
+
+    @Test
+    void createFromUrlAcceptsOwnerExternalSubject() throws Exception {
+        UUID ownerId = UUID.randomUUID();
+        UUID mediaId = UUID.randomUUID();
+        String externalSubject = "demo-user-1";
+        String url = "https://example.com/audio.mp4";
+
+        Account account = mock(Account.class);
+        when(account.getId()).thenReturn(ownerId);
+        when(accountService.getByExternalSubjectOrThrow(externalSubject)).thenReturn(account);
+        when(metadataService.normalizeUrl(url)).thenReturn(url);
+        when(metadataService.detectPlatform(url)).thenReturn(MediaPlatform.OTHER);
+        when(mediaService.createMediaFromUrl(eq(ownerId), eq(url), eq(MediaPlatform.OTHER), eq("url"), any(), any(), any()))
+                .thenReturn(mediaId);
+
+        Media media = new Media();
+        media.setOwner(account);
+        media.setObjectKey("ext/url/abc/source.m4a");
+        when(mediaService.get(mediaId)).thenReturn(media);
+
+        String body = objectMapper.writeValueAsString(Map.of(
+                "ownerExternalSubject", externalSubject,
+                "url", url
+        ));
+
+        var mvcResult = mockMvc.perform(post("/v1/media/from-url")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mediaId").value(mediaId.toString()))
+                .andExpect(jsonPath("$.objectKey").value("ext/url/abc/source.m4a"))
+                .andReturn();
+
+        verify(mediaService).createMediaFromUrl(eq(ownerId), eq(url), eq(MediaPlatform.OTHER), eq("url"), any(), any(), any());
+        assertThat(mvcResult.getResponse().getContentAsString()).contains("DOWNLOADING");
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/controller/MediaControllerTest.java
+++ b/src/test/java/com/example/clipbot_backend/controller/MediaControllerTest.java
@@ -119,4 +119,22 @@ class MediaControllerTest {
         verify(accountService).getByExternalSubjectOrThrow(externalSubject);
         verify(mediaService).createMediaFromUrl(eq(ownerId), eq(url), eq(MediaPlatform.OTHER), eq("url"), any(), any(), any());
     }
+
+    @Test
+    void createFromUrlRejectsConflictingOwnerInputs() throws Exception {
+        String ownerIdRaw = "demo-user-1";
+        String externalSubject = "other-user";
+        String url = "https://example.com/audio.mp4";
+
+        String body = objectMapper.writeValueAsString(Map.of(
+                "ownerId", ownerIdRaw,
+                "ownerExternalSubject", externalSubject,
+                "url", url
+        ));
+
+        mockMvc.perform(post("/v1/media/from-url")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/com/example/clipbot_backend/engine/GptDiarizeTranscriptionEngineTest.java
+++ b/src/test/java/com/example/clipbot_backend/engine/GptDiarizeTranscriptionEngineTest.java
@@ -1,0 +1,132 @@
+package com.example.clipbot_backend.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.example.clipbot_backend.config.OpenAIAudioProperties;
+import com.example.clipbot_backend.engine.Interfaces.GptDiarizeTranscriptionEngine;
+import com.example.clipbot_backend.engine.Interfaces.TranscriptionEngine;
+import com.example.clipbot_backend.service.Interfaces.StorageService;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.client.reactive.MockClientHttpRequest;
+import org.springframework.web.reactive.function.BodyInserter;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.http.codec.HttpMessageWriter;
+import reactor.core.publisher.Mono;
+
+class GptDiarizeTranscriptionEngineTest {
+
+    private Path tempFile;
+
+    @BeforeEach
+    void setup() throws Exception {
+        tempFile = Files.createTempFile("gpt-diarize", ".wav");
+        Files.writeString(tempFile, "data");
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        Files.deleteIfExists(tempFile);
+    }
+
+    @Test
+    void transcribeSendsVerboseJsonAndDiarizationFlags() throws Exception {
+        StorageService storage = Mockito.mock(StorageService.class);
+        when(storage.resolveRaw("obj"))
+                .thenReturn(tempFile);
+
+        OpenAIAudioProperties props = new OpenAIAudioProperties();
+        ExchangeStrategies strategies = ExchangeStrategies.withDefaults();
+
+        ExchangeFunction exchangeFunction = request -> {
+            MockClientHttpRequest mockRequest = new MockClientHttpRequest(request.method(), request.url());
+            request.body().insert(mockRequest, new BodyInserter.Context() {
+                @Override
+                public List<HttpMessageWriter<?>> messageWriters() {
+                    return strategies.messageWriters();
+                }
+
+                @Override
+                public Optional<ServerHttpRequest> serverRequest() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Map<String, Object> hints() {
+                    return Map.of();
+                }
+            }).block();
+
+            String body = mockRequest.getBodyAsString().block();
+            assertThat(body).contains("response_format")
+                    .contains("verbose_json")
+                    .contains("diarization")
+                    .contains("timestamp_granularities[]")
+                    .contains("segment")
+                    .contains("word");
+            assertThat(mockRequest.getHeaders().getContentType()).isEqualTo(MediaType.MULTIPART_FORM_DATA);
+
+            String responseJson = "{\"text\":\"hi\",\"language\":\"en\",\"segments\":[]}";
+            ClientResponse response = ClientResponse.create(HttpStatus.OK)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .body(responseJson)
+                    .build();
+            return Mono.just(response);
+        };
+
+        WebClient client = WebClient.builder()
+                .exchangeFunction(exchangeFunction)
+                .build();
+
+        TranscriptionEngine engine = new GptDiarizeTranscriptionEngine(storage, client, props);
+        engine.transcribe(new TranscriptionEngine.Request(UUID.randomUUID(), "obj", "en"));
+    }
+
+    @Test
+    void nonSuccessResponsesIncludeStatusAndBody() throws Exception {
+        StorageService storage = Mockito.mock(StorageService.class);
+        when(storage.resolveRaw("obj"))
+                .thenReturn(tempFile);
+
+        OpenAIAudioProperties props = new OpenAIAudioProperties();
+
+        ExchangeFunction exchangeFunction = request -> {
+            String errorJson = "{\"error\":\"bad\"}";
+            ClientResponse response = ClientResponse.create(HttpStatus.BAD_REQUEST)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .body(errorJson)
+                    .build();
+            return Mono.just(response);
+        };
+
+        WebClient client = WebClient.builder()
+                .exchangeFunction(exchangeFunction)
+                .build();
+
+        TranscriptionEngine engine = new GptDiarizeTranscriptionEngine(storage, client, props);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> engine.transcribe(new TranscriptionEngine.Request(UUID.randomUUID(), "obj", "en")));
+
+        assertThat(ex.getMessage()).contains("status=400")
+                .contains("body=")
+                .contains("{\"error\":\"bad\"}");
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/engine/GptDiarizeTranscriptionEngineTest.java
+++ b/src/test/java/com/example/clipbot_backend/engine/GptDiarizeTranscriptionEngineTest.java
@@ -77,6 +77,8 @@ class GptDiarizeTranscriptionEngineTest {
             String body = mockRequest.getBodyAsString().block();
             assertThat(body).contains("response_format")
                     .contains("diarized_json")
+                    .contains("chunking_strategy")
+                    .contains("auto")
                     .contains("diarization")
                     .doesNotContain("timestamp_granularities[]")
                     .doesNotContain("word");

--- a/src/test/java/com/example/clipbot_backend/engine/GptDiarizeTranscriptionEngineTest.java
+++ b/src/test/java/com/example/clipbot_backend/engine/GptDiarizeTranscriptionEngineTest.java
@@ -47,7 +47,7 @@ class GptDiarizeTranscriptionEngineTest {
     }
 
     @Test
-    void transcribeSendsVerboseJsonAndDiarizationFlags() throws Exception {
+    void transcribeSendsDiarizedJsonWithoutWordGranularities() throws Exception {
         StorageService storage = Mockito.mock(StorageService.class);
         when(storage.resolveRaw("obj"))
                 .thenReturn(tempFile);
@@ -76,11 +76,10 @@ class GptDiarizeTranscriptionEngineTest {
 
             String body = mockRequest.getBodyAsString().block();
             assertThat(body).contains("response_format")
-                    .contains("verbose_json")
+                    .contains("diarized_json")
                     .contains("diarization")
-                    .contains("timestamp_granularities[]")
-                    .contains("segment")
-                    .contains("word");
+                    .doesNotContain("timestamp_granularities[]")
+                    .doesNotContain("word");
             assertThat(mockRequest.getHeaders().getContentType()).isEqualTo(MediaType.MULTIPART_FORM_DATA);
 
             String responseJson = "{\"text\":\"hi\",\"language\":\"en\",\"segments\":[]}";

--- a/src/test/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngineFormatTest.java
+++ b/src/test/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngineFormatTest.java
@@ -91,7 +91,11 @@ class OpenAITranscriptionEngineFormatTest {
         engine.transcribe(new TranscriptionEngine.Request(UUID.randomUUID(), "obj", "en"));
 
         String body = bodyRef.get();
-        assertThat(body).contains("name=\"response_format\"").contains("diarized_json");
+        assertThat(body)
+                .contains("name=\"response_format\"")
+                .contains("diarized_json")
+                .contains("name=\"chunking_strategy\"")
+                .contains("auto");
         assertThat(body).doesNotContain("timestamp_granularities");
     }
 

--- a/src/test/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngineFormatTest.java
+++ b/src/test/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngineFormatTest.java
@@ -175,7 +175,10 @@ class OpenAITranscriptionEngineFormatTest {
         TranscriptionEngine.Result result = engine.transcribe(new TranscriptionEngine.Request(UUID.randomUUID(), "obj", "en"));
 
         assertThat(result.text()).isEqualTo("Hello there Hi again");
-        assertThat(result.words()).isEmpty();
+        assertThat(result.words()).hasSizeGreaterThan(2);
+        assertThat(result.words())
+                .extracting(TranscriptionEngine.Word::startMs)
+                .isSorted();
         assertThat(result.meta()).containsEntry("provider", "openai");
         assertThat((List<?>) result.meta().get("segments")).hasSize(2);
     }

--- a/src/test/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngineFormatTest.java
+++ b/src/test/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngineFormatTest.java
@@ -256,7 +256,7 @@ class OpenAITranscriptionEngineFormatTest {
 
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(OpenAITranscriptionEngine.class);
         Level previous = logger.getLevel();
-        logger.setLevel(Level.DEBUG);
+        logger.setLevel(Level.INFO);
         ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
         listAppender.start();
         logger.addAppender(listAppender);
@@ -271,13 +271,13 @@ class OpenAITranscriptionEngineFormatTest {
                     .isSorted();
             assertThat(result.meta()).containsKey("segments");
 
-            List<String> debugMessages = listAppender.list.stream()
-                    .filter(event -> event.getLevel() == Level.DEBUG)
+            List<String> infoMessages = listAppender.list.stream()
+                    .filter(event -> event.getLevel().isGreaterOrEqual(Level.INFO))
                     .map(ILoggingEvent::getFormattedMessage)
                     .toList();
 
-            assertThat(debugMessages).anyMatch(msg -> msg.contains("raw response"));
-            assertThat(debugMessages).anyMatch(msg -> msg.contains("parsed root"));
+            assertThat(infoMessages).anyMatch(msg -> msg.contains("raw response"));
+            assertThat(infoMessages).anyMatch(msg -> msg.contains("parsed root"));
         } finally {
             logger.setLevel(previous);
             logger.detachAppender(listAppender);

--- a/src/test/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngineRetryTest.java
+++ b/src/test/java/com/example/clipbot_backend/engine/OpenAITranscriptionEngineRetryTest.java
@@ -1,0 +1,129 @@
+package com.example.clipbot_backend.engine;
+
+import com.example.clipbot_backend.config.OpenAIAudioProperties;
+import com.example.clipbot_backend.engine.Interfaces.TranscriptionEngine;
+import com.example.clipbot_backend.service.Interfaces.StorageService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.client.reactive.MockClientHttpRequest;
+import org.springframework.web.reactive.function.BodyInserter;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.http.codec.HttpMessageWriter;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.PrematureCloseException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+class OpenAITranscriptionEngineRetryTest {
+
+    private Path tempFile;
+
+    @BeforeEach
+    void setup() throws Exception {
+        tempFile = Files.createTempFile("openai-retry", ".wav");
+        Files.writeString(tempFile, "data");
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        Files.deleteIfExists(tempFile);
+    }
+
+    @Test
+    void retriesOnPrematureCloseException() throws Exception {
+        StorageService storage = Mockito.mock(StorageService.class);
+        when(storage.resolveRaw("obj")).thenReturn(tempFile);
+
+        OpenAIAudioProperties props = new OpenAIAudioProperties();
+        ExchangeStrategies strategies = ExchangeStrategies.withDefaults();
+        AtomicInteger attempts = new AtomicInteger();
+
+        ExchangeFunction exchangeFunction = request -> {
+            int attempt = attempts.incrementAndGet();
+            if (attempt < 3) {
+                return Mono.error(new PrematureCloseException("closed"));
+            }
+
+            MockClientHttpRequest mockRequest = new MockClientHttpRequest(request.method(), request.url());
+            request.body().insert(mockRequest, new BodyInserter.Context() {
+                @Override
+                public List<HttpMessageWriter<?>> messageWriters() {
+                    return strategies.messageWriters();
+                }
+
+                @Override
+                public Optional<ServerHttpRequest> serverRequest() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Map<String, Object> hints() {
+                    return Map.of();
+                }
+            }).block();
+
+            ClientResponse response = ClientResponse.create(HttpStatus.OK)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .body("{\"text\":\"ok\",\"language\":\"en\",\"segments\":[]}")
+                    .build();
+            return Mono.just(response);
+        };
+
+        WebClient client = WebClient.builder()
+                .exchangeFunction(exchangeFunction)
+                .build();
+
+        TranscriptionEngine engine = new OpenAITranscriptionEngine(storage, client, props);
+        TranscriptionEngine.Result result = engine.transcribe(new TranscriptionEngine.Request(UUID.randomUUID(), "obj", "en"));
+
+        assertThat(attempts.get()).isEqualTo(3);
+        assertThat(result.text()).isEqualTo("ok");
+    }
+
+    @Test
+    void doesNotRetryOn4xxErrors() throws Exception {
+        StorageService storage = Mockito.mock(StorageService.class);
+        when(storage.resolveRaw("obj")).thenReturn(tempFile);
+
+        OpenAIAudioProperties props = new OpenAIAudioProperties();
+        AtomicInteger attempts = new AtomicInteger();
+
+        ExchangeFunction exchangeFunction = request -> {
+            attempts.incrementAndGet();
+            ClientResponse response = ClientResponse.create(HttpStatus.BAD_REQUEST)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .body("{\"error\":\"bad\"}")
+                    .build();
+            return Mono.just(response);
+        };
+
+        WebClient client = WebClient.builder()
+                .exchangeFunction(exchangeFunction)
+                .build();
+
+        TranscriptionEngine engine = new OpenAITranscriptionEngine(storage, client, props);
+
+        assertThrows(RuntimeException.class,
+                () -> engine.transcribe(new TranscriptionEngine.Request(UUID.randomUUID(), "obj", "en")));
+        assertThat(attempts.get()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/service/DetectWorkflowEngineSelectionTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/DetectWorkflowEngineSelectionTest.java
@@ -57,6 +57,8 @@ class DetectWorkflowEngineSelectionTest {
     private UrlDownloader urlDownloader;
     @Mock
     private RecommendationService recommendationService;
+    @Mock
+    private com.example.clipbot_backend.service.thumbnail.ThumbnailService thumbnailService;
 
     private DetectWorkflow detectWorkflow;
     private Path tempFile;
@@ -74,7 +76,8 @@ class DetectWorkflowEngineSelectionTest {
                 fasterEngine,
                 audioWindowService,
                 urlDownloader,
-                recommendationService
+                recommendationService,
+                thumbnailService
         );
         tempFile = Files.createTempFile("dw", ".mp4");
         Files.write(tempFile, new byte[]{1, 2, 3});

--- a/src/test/java/com/example/clipbot_backend/service/DetectWorkflowEngineSelectionTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/DetectWorkflowEngineSelectionTest.java
@@ -1,0 +1,140 @@
+package com.example.clipbot_backend.service;
+
+import com.example.clipbot_backend.dto.DetectionParams;
+import com.example.clipbot_backend.engine.Interfaces.DetectionEngine;
+import com.example.clipbot_backend.engine.Interfaces.TranscriptionEngine;
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.model.Transcript;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.repository.SegmentRepository;
+import com.example.clipbot_backend.repository.TranscriptRepository;
+import com.example.clipbot_backend.service.Interfaces.StorageService;
+import com.example.clipbot_backend.service.Interfaces.TranscriptService;
+import com.example.clipbot_backend.util.MediaStatus;
+import com.example.clipbot_backend.util.SpeakerMode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DetectWorkflowEngineSelectionTest {
+
+    @Mock
+    private MediaRepository mediaRepository;
+    @Mock
+    private TranscriptRepository transcriptRepository;
+    @Mock
+    private SegmentRepository segmentRepository;
+    @Mock
+    private StorageService storageService;
+    @Mock
+    private DetectionEngine detectionEngine;
+    @Mock
+    private TranscriptService transcriptService;
+    @Mock
+    private TranscriptionEngine gptEngine;
+    @Mock
+    private TranscriptionEngine fasterEngine;
+    @Mock
+    private AudioWindowService audioWindowService;
+    @Mock
+    private UrlDownloader urlDownloader;
+    @Mock
+    private RecommendationService recommendationService;
+
+    private DetectWorkflow detectWorkflow;
+    private Path tempFile;
+
+    @BeforeEach
+    void setup() throws Exception {
+        detectWorkflow = new DetectWorkflow(
+                mediaRepository,
+                transcriptRepository,
+                segmentRepository,
+                storageService,
+                detectionEngine,
+                transcriptService,
+                gptEngine,
+                fasterEngine,
+                audioWindowService,
+                urlDownloader,
+                recommendationService
+        );
+        tempFile = Files.createTempFile("dw", ".mp4");
+        Files.write(tempFile, new byte[]{1, 2, 3});
+    }
+
+    @Test
+    void multiSpeakerUsesGptDiarizeEvenWhenJobProviderIsFw() throws Exception {
+        Media media = buildMedia(SpeakerMode.MULTI);
+        Transcript transcript = new Transcript();
+        transcript.setMedia(media);
+        UUID transcriptId = UUID.randomUUID();
+
+        when(mediaRepository.findById(media.getId())).thenReturn(Optional.of(media));
+        when(transcriptRepository.findTopByMediaOrderByCreatedAtDesc(media)).thenReturn(Optional.empty());
+        when(storageService.resolveRaw(media.getObjectKey())).thenReturn(tempFile);
+        when(gptEngine.transcribe(any())).thenReturn(new TranscriptionEngine.Result("text", List.of(), "en", "gpt", Map.of()));
+        when(transcriptService.upsert(media.getId(), any())).thenReturn(transcriptId);
+        when(transcriptRepository.findById(transcriptId)).thenReturn(Optional.of(transcript));
+        when(segmentRepository.deleteByMedia(media)).thenReturn(0);
+        when(detectionEngine.detect(any(Path.class), any(Transcript.class), any(DetectionParams.class)))
+                .thenReturn(List.of());
+
+        int count = detectWorkflow.run(media.getId(), Map.of("provider", "fw"));
+
+        assertThat(count).isZero();
+        verify(gptEngine).transcribe(any());
+        verify(fasterEngine, never()).transcribe(any());
+    }
+
+    @Test
+    void singleSpeakerStaysOnFasterWhisper() throws Exception {
+        Media media = buildMedia(SpeakerMode.SINGLE);
+        Transcript transcript = new Transcript();
+        transcript.setMedia(media);
+        UUID transcriptId = UUID.randomUUID();
+
+        when(mediaRepository.findById(media.getId())).thenReturn(Optional.of(media));
+        when(transcriptRepository.findTopByMediaOrderByCreatedAtDesc(media)).thenReturn(Optional.empty());
+        when(storageService.resolveRaw(media.getObjectKey())).thenReturn(tempFile);
+        when(fasterEngine.transcribe(any())).thenReturn(new TranscriptionEngine.Result("text", List.of(), "en", "fw", Map.of()));
+        when(transcriptService.upsert(media.getId(), any())).thenReturn(transcriptId);
+        when(transcriptRepository.findById(transcriptId)).thenReturn(Optional.of(transcript));
+        when(segmentRepository.deleteByMedia(media)).thenReturn(0);
+        when(detectionEngine.detect(any(Path.class), any(Transcript.class), any(DetectionParams.class)))
+                .thenReturn(List.of());
+
+        detectWorkflow.run(media.getId(), Map.of());
+
+        verify(fasterEngine).transcribe(any());
+        verify(gptEngine, never()).transcribe(any());
+    }
+
+    private Media buildMedia(SpeakerMode mode) {
+        Media media = new Media();
+        media.setId(UUID.randomUUID());
+        media.setSpeakerMode(mode);
+        media.setStatus(MediaStatus.PROCESSING);
+        media.setObjectKey("object-key.mp4");
+        media.setSource("upload");
+        media.setOwner(new Account("ext", "owner"));
+        return media;
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/service/MediaSpeakerModeIngestTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/MediaSpeakerModeIngestTest.java
@@ -1,0 +1,102 @@
+package com.example.clipbot_backend.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.repository.AccountRepository;
+import com.example.clipbot_backend.repository.AssetRepository;
+import com.example.clipbot_backend.repository.JobRepository;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.util.MediaPlatform;
+import com.example.clipbot_backend.util.SpeakerMode;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MediaSpeakerModeIngestTest {
+
+    @Mock
+    private MediaRepository mediaRepository;
+    @Mock
+    private AccountService accountService;
+
+    @Mock
+    private com.example.clipbot_backend.service.Interfaces.StorageService storageService;
+    @Mock
+    private AccountRepository accountRepository;
+    @Mock
+    private AssetRepository assetRepository;
+    @Mock
+    private JobRepository jobRepository;
+    @Mock
+    private JobService jobService;
+
+    private MediaService mediaService;
+    private UploadService uploadService;
+
+    @BeforeEach
+    void setup() {
+        mediaService = new MediaService(mediaRepository, accountService);
+        uploadService = new UploadService(storageService, accountRepository, mediaRepository, assetRepository, jobRepository, jobService);
+    }
+
+    @Test
+    void podcastIntentPersistsMultiSpeakerModeOnUrlIngest() {
+        UUID ownerId = UUID.randomUUID();
+        Account owner = new Account("ext", "owner");
+        ReflectionTestUtils.setField(owner, "id", ownerId);
+        when(accountService.getByIdOrThrow(ownerId)).thenReturn(owner);
+        when(mediaRepository.save(any(Media.class))).thenAnswer(invocation -> {
+            Media m = invocation.getArgument(0);
+            m.setId(UUID.randomUUID());
+            return m;
+        });
+
+        UUID id = mediaService.createMediaFromUrl(ownerId, "http://example.com", MediaPlatform.OTHER, "url", null, null, SpeakerMode.MULTI);
+
+        ArgumentCaptor<Media> captor = ArgumentCaptor.forClass(Media.class);
+        assertThat(id).isNotNull();
+        org.mockito.Mockito.verify(mediaRepository).save(captor.capture());
+        assertThat(captor.getValue().getSpeakerMode()).isEqualTo(SpeakerMode.MULTI);
+    }
+
+    @Test
+    void uploadLocalSetsSpeakerModeFromPodcastFlag() throws Exception {
+        Account owner = new Account("ext", "owner");
+        ReflectionTestUtils.setField(owner, "id", UUID.randomUUID());
+        when(accountRepository.findByExternalSubject(anyString())).thenReturn(Optional.empty());
+        when(accountRepository.save(any(Account.class))).thenReturn(owner);
+
+        when(mediaRepository.saveAndFlush(any(Media.class))).thenAnswer(invocation -> {
+            Media m = invocation.getArgument(0);
+            m.setId(UUID.randomUUID());
+            return m;
+        });
+        when(mediaRepository.save(any(Media.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        when(assetRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(storageService.resolveRaw(anyString())).thenReturn(Path.of("/tmp"));
+        org.mockito.Mockito.doNothing().when(storageService).uploadToRaw(any(Path.class), anyString());
+        when(jobService.enqueue(any(), any(), any())).thenReturn(UUID.randomUUID());
+
+        MockMultipartFile file = new MockMultipartFile("file", "sample.mp4", "video/mp4", new byte[]{1, 2, 3});
+        uploadService.uploadLocal("ext", null, file, "upload", true);
+
+        ArgumentCaptor<Media> captor = ArgumentCaptor.forClass(Media.class);
+        org.mockito.Mockito.verify(mediaRepository).saveAndFlush(captor.capture());
+        assertThat(captor.getValue().getSpeakerMode()).isEqualTo(SpeakerMode.MULTI);
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
@@ -110,7 +110,7 @@ class OneClickOrchestratorTest {
                 .thenReturn(Optional.empty());
         when(projectService.findByNormalizedUrl(anyString(), anyString())).thenReturn(Optional.empty());
         when(projectService.createProjectBySubject(anyString(), anyString(), any(), any())).thenReturn(project);
-        when(mediaService.createMediaFromUrl(any(), any(), any(), anyString(), any(), any())).thenReturn(mediaId);
+        when(mediaService.createMediaFromUrl(any(), any(), any(), anyString(), any(), any(), any())).thenReturn(mediaId);
         when(detectionService.enqueueDetect(any(), anyString(), anyString(), any(), any(), any())).thenReturn(jobId);
         when(transcriptRepository.existsByMediaId(mediaId)).thenReturn(true);
         when(segmentRepository.countByMediaId(mediaId)).thenReturn(3L);
@@ -168,7 +168,7 @@ class OneClickOrchestratorTest {
 
         assertThat(response.getMediaId()).isEqualTo(mediaId);
         assertThat(response.isCreatedProject()).isTrue();
-        verify(mediaService, never()).createMediaFromUrl(any(), any(), any(), anyString(), any(), any());
+        verify(mediaService, never()).createMediaFromUrl(any(), any(), any(), anyString(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/OneClickOrchestratorTest.java
@@ -131,9 +131,10 @@ class OneClickOrchestratorTest {
         assertThat(response.isCreatedProject()).isTrue();
         assertThat(response.getDetectJob()).isEqualTo(new OneClickJob(jobId, "ENQUEUED"));
         assertThat(response.getRecommendations().computed()).isEqualTo(2);
-        assertThat(response.getThumbnailSource()).isEqualTo("YOUTUBE");
+        assertThat(response.getThumbnailSource()).isEqualTo("DEFERRED");
 
-        verify(projectService).patch(projectId, org.mockito.ArgumentMatchers.any());
+        verify(projectService, never()).patch(any(), any());
+        verifyNoInteractions(thumbnailService);
     }
 
     @Test
@@ -180,6 +181,7 @@ class OneClickOrchestratorTest {
         assertThat(detectPayload).containsEntry("topN", 6);
         assertThat(detectPayload).containsEntry("enqueueRender", true);
         verifyNoInteractions(detectionService);
+        verifyNoInteractions(thumbnailService);
     }
 
     @Test

--- a/src/test/java/com/example/clipbot_backend/service/UrlDownloaderFailureTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/UrlDownloaderFailureTest.java
@@ -1,10 +1,14 @@
 package com.example.clipbot_backend.service;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.example.clipbot_backend.service.Interfaces.StorageService;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -23,32 +27,88 @@ class UrlDownloaderFailureTest {
     private Path tempDir;
 
     @Test
-    void youtubeDownloadFailureSurfacesYtDlpLog() {
+    void youtubeDownloadFailureSurfacesAuthWall() {
         Path target = tempDir.resolve("ext/yt/video/source.mp4");
         when(storageService.resolveRaw("ext/yt/video/source.mp4")).thenReturn(target);
 
         UrlDownloader downloader = new TestDownloader(storageService,
-                "Sign in to confirm you're not a bot.", 1);
+                "Sign in to confirm you're not a bot.", 1, false, target, null);
 
         IllegalStateException ex = assertThrows(IllegalStateException.class, () ->
                 downloader.ensureRawObject("https://www.youtube.com/watch?v=video", "ext/yt/video/source.mp4"));
 
         String message = ex.getMessage();
-        assertTrue(message.contains("yt-dlp exit=1"));
+        assertTrue(message.contains("authentication/cookies"));
         assertTrue(message.contains("Sign in to confirm you're not a bot."));
     }
 
-    private static final class TestDownloader extends UrlDownloader {
+    @Test
+    void youtubeDownloadTimeoutIsSurfaced() {
+        Path target = tempDir.resolve("ext/yt/video/source.mp4");
+        when(storageService.resolveRaw("ext/yt/video/source.mp4")).thenReturn(target);
+
+        UrlDownloader downloader = new TestDownloader(storageService,
+                "processing...", -1, true, target, null);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () ->
+                downloader.ensureRawObject("https://www.youtube.com/watch?v=video", "ext/yt/video/source.mp4"));
+
+        assertTrue(ex.getMessage().toLowerCase().contains("timeout"));
+    }
+
+    @Test
+    void cookiesFileIsAddedWhenPresent() {
+        Path target = tempDir.resolve("ext/yt/video/source.mp4");
+        when(storageService.resolveRaw("ext/yt/video/source.mp4")).thenReturn(target);
+
+        Path cookies = tempDir.resolve("cookies.txt");
+        assertDoesNotThrow(() -> Files.writeString(cookies, "dummy"));
+
+        CapturingDownloader downloader = new CapturingDownloader(storageService,
+                "ok", 0, false, target, cookies);
+
+        assertDoesNotThrow(() -> downloader.ensureRawObject("https://www.youtube.com/watch?v=video", "ext/yt/video/source.mp4"));
+
+        assertTrue(downloader.lastCmd.contains("--cookies"));
+        int idx = downloader.lastCmd.indexOf("--cookies");
+        assertEquals(cookies.toAbsolutePath().toString(), downloader.lastCmd.get(idx + 1));
+    }
+
+    private static class TestDownloader extends UrlDownloader {
         private final ProcessResult stubResult;
 
-        TestDownloader(StorageService storageService, String log, int code) {
-            super(storageService, "yt-dlp", 120, "JUnit-UA", 3, "ffmpeg");
-            this.stubResult = new ProcessResult(code, log);
+        TestDownloader(StorageService storageService, String log, int code, boolean timeout, Path target, Path cookies) {
+            super(storageService, "yt-dlp", 120, "JUnit-UA", 3, "ffmpeg", cookies != null ? cookies.toString() : null);
+            this.stubResult = new ProcessResult(code, log, timeout);
+            this.target = target;
+        }
+
+        private final Path target;
+
+        @Override
+        protected ProcessResult runProcess(List<String> cmd, long timeoutMinutes) {
+            try {
+                Files.createDirectories(target.getParent());
+                if (stubResult.code() == 0 && !stubResult.timedOut()) {
+                    Files.createFile(target);
+                }
+            } catch (IOException ignored) {
+            }
+            return stubResult;
+        }
+    }
+
+    private static final class CapturingDownloader extends TestDownloader {
+        private List<String> lastCmd;
+
+        CapturingDownloader(StorageService storageService, String log, int code, boolean timeout, Path target, Path cookies) {
+            super(storageService, log, code, timeout, target, cookies);
         }
 
         @Override
-        protected ProcessResult runProcess(List<String> cmd) {
-            return stubResult;
+        protected ProcessResult runProcess(List<String> cmd, long timeoutMinutes) {
+            this.lastCmd = cmd;
+            return super.runProcess(cmd, timeoutMinutes);
         }
     }
 }

--- a/src/test/java/com/example/clipbot_backend/service/UrlDownloaderFailureTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/UrlDownloaderFailureTest.java
@@ -1,0 +1,54 @@
+package com.example.clipbot_backend.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.example.clipbot_backend.service.Interfaces.StorageService;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UrlDownloaderFailureTest {
+
+    @Mock
+    private StorageService storageService;
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void youtubeDownloadFailureSurfacesYtDlpLog() {
+        Path target = tempDir.resolve("ext/yt/video/source.mp4");
+        when(storageService.resolveRaw("ext/yt/video/source.mp4")).thenReturn(target);
+
+        UrlDownloader downloader = new TestDownloader(storageService,
+                "Sign in to confirm you're not a bot.", 1);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () ->
+                downloader.ensureRawObject("https://www.youtube.com/watch?v=video", "ext/yt/video/source.mp4"));
+
+        String message = ex.getMessage();
+        assertTrue(message.contains("yt-dlp exit=1"));
+        assertTrue(message.contains("Sign in to confirm you're not a bot."));
+    }
+
+    private static final class TestDownloader extends UrlDownloader {
+        private final ProcessResult stubResult;
+
+        TestDownloader(StorageService storageService, String log, int code) {
+            super(storageService, "yt-dlp", 120, "JUnit-UA", 3, "ffmpeg");
+            this.stubResult = new ProcessResult(code, log);
+        }
+
+        @Override
+        protected ProcessResult runProcess(List<String> cmd) {
+            return stubResult;
+        }
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/service/WorkerServiceTranscriptionSelectionTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/WorkerServiceTranscriptionSelectionTest.java
@@ -1,0 +1,165 @@
+package com.example.clipbot_backend.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.clipbot_backend.engine.Interfaces.ClipRenderEngine;
+import com.example.clipbot_backend.engine.Interfaces.DetectionEngine;
+import com.example.clipbot_backend.engine.Interfaces.TranscriptionEngine;
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Job;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.repository.AssetRepository;
+import com.example.clipbot_backend.repository.ClipRepository;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.repository.SegmentRepository;
+import com.example.clipbot_backend.repository.TranscriptRepository;
+import com.example.clipbot_backend.service.AudioWindowService;
+import com.example.clipbot_backend.service.ClipService;
+import com.example.clipbot_backend.service.ClipWorkFlow;
+import com.example.clipbot_backend.service.DetectWorkflow;
+import com.example.clipbot_backend.service.FasterWhisperClient;
+import com.example.clipbot_backend.service.Interfaces.StorageService;
+import com.example.clipbot_backend.service.Interfaces.SubtitleService;
+import com.example.clipbot_backend.service.RenderService;
+import com.example.clipbot_backend.service.UrlDownloader;
+import com.example.clipbot_backend.util.JobType;
+import com.example.clipbot_backend.util.SpeakerMode;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkerServiceTranscriptionSelectionTest {
+
+    @Mock
+    private JobService jobService;
+    @Mock
+    private TranscriptService transcriptService;
+    @Mock
+    private MediaRepository mediaRepository;
+    @Mock
+    private TranscriptRepository transcriptRepository;
+    @Mock
+    private SegmentRepository segmentRepository;
+    @Mock
+    private ClipRepository clipRepository;
+    @Mock
+    private AssetRepository assetRepository;
+    @Mock
+    private UrlDownloader urlDownloader;
+    @Mock
+    private FasterWhisperClient fastWhisperClient;
+    @Mock
+    private AudioWindowService audioWindowService;
+    @Mock
+    private DetectWorkflow detectWorkflow;
+    @Mock
+    private ClipWorkFlow clipWorkFlow;
+    @Mock
+    private ClipService clipService;
+    @Mock
+    private DetectionEngine detectionEngine;
+    @Mock
+    private ClipRenderEngine clipRenderEngine;
+    @Mock
+    private StorageService storageService;
+    @Mock
+    private SubtitleService subtitleService;
+    @Mock
+    private RenderService renderService;
+    @Mock
+    private TranscriptionEngine gptEngine;
+    @Mock
+    private TranscriptionEngine fasterEngine;
+
+    private WorkerService workerService;
+    private Path tempMedia;
+
+    @BeforeEach
+    void setup() throws Exception {
+        workerService = new WorkerService(jobService, transcriptService, mediaRepository, transcriptRepository, segmentRepository,
+                clipRepository, assetRepository, urlDownloader, fastWhisperClient, audioWindowService, detectWorkflow,
+                clipWorkFlow, clipService, detectionEngine, clipRenderEngine, storageService, subtitleService, renderService,
+                gptEngine, fasterEngine);
+        tempMedia = Files.createTempFile("media", ".mp4");
+        Files.write(tempMedia, new byte[]{1, 2, 3});
+    }
+
+    @Test
+    void multiSpeakerUsesGptEngine() throws Exception {
+        Media media = buildMedia(SpeakerMode.MULTI);
+        Job job = buildJob(media);
+        when(transcriptService.existsAnyFor(media.getId())).thenReturn(false);
+        when(mediaRepository.findById(media.getId())).thenReturn(Optional.of(media));
+        when(storageService.resolveRaw(media.getObjectKey())).thenReturn(tempMedia);
+        when(gptEngine.transcribe(any())).thenReturn(new TranscriptionEngine.Result("text", java.util.List.of(), "en", "GPT_DIARIZE", Map.of()));
+        when(transcriptService.upsert(any(), any())).thenReturn(UUID.randomUUID());
+
+        workerService.handleTranscribe(job);
+
+        verify(gptEngine, times(1)).transcribe(any());
+        verify(fasterEngine, never()).transcribe(any());
+    }
+
+    @Test
+    void gptFailureFallsBackToFasterWhisper() throws Exception {
+        Media media = buildMedia(SpeakerMode.MULTI);
+        Job job = buildJob(media);
+        when(transcriptService.existsAnyFor(media.getId())).thenReturn(false);
+        when(mediaRepository.findById(media.getId())).thenReturn(Optional.of(media));
+        when(storageService.resolveRaw(media.getObjectKey())).thenReturn(tempMedia);
+        when(gptEngine.transcribe(any())).thenThrow(new RuntimeException("gpt failed"));
+        when(fasterEngine.transcribe(any())).thenReturn(new TranscriptionEngine.Result("text", java.util.List.of(), "en", "FW", Map.of()));
+        when(transcriptService.upsert(any(), any())).thenReturn(UUID.randomUUID());
+
+        workerService.handleTranscribe(job);
+
+        verify(gptEngine, times(1)).transcribe(any());
+        verify(fasterEngine, times(1)).transcribe(any());
+    }
+
+    @Test
+    void singleSpeakerUsesFasterWhisper() throws Exception {
+        Media media = buildMedia(SpeakerMode.SINGLE);
+        Job job = buildJob(media);
+        when(transcriptService.existsAnyFor(media.getId())).thenReturn(false);
+        when(mediaRepository.findById(media.getId())).thenReturn(Optional.of(media));
+        when(storageService.resolveRaw(media.getObjectKey())).thenReturn(tempMedia);
+        when(fasterEngine.transcribe(any())).thenReturn(new TranscriptionEngine.Result("text", java.util.List.of(), "en", "FW", Map.of()));
+        when(transcriptService.upsert(any(), any())).thenReturn(UUID.randomUUID());
+
+        workerService.handleTranscribe(job);
+
+        verify(fasterEngine, times(1)).transcribe(any());
+        verify(gptEngine, never()).transcribe(any());
+    }
+
+    private Media buildMedia(SpeakerMode mode) {
+        Media media = new Media();
+        media.setId(UUID.randomUUID());
+        media.setSpeakerMode(mode);
+        media.setObjectKey("object-key.mp4");
+        media.setSource("upload");
+        media.setOwner(new Account("ext", "owner"));
+        return media;
+    }
+
+    private Job buildJob(Media media) {
+        Job job = new Job(JobType.TRANSCRIBE);
+        job.setId(UUID.randomUUID());
+        job.setMedia(media);
+        job.setPayload(Map.of());
+        return job;
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/service/thumbnail/ThumbnailServiceExtractionTest.java
+++ b/src/test/java/com/example/clipbot_backend/service/thumbnail/ThumbnailServiceExtractionTest.java
@@ -1,0 +1,115 @@
+package com.example.clipbot_backend.service.thumbnail;
+
+import com.example.clipbot_backend.model.Account;
+import com.example.clipbot_backend.model.Media;
+import com.example.clipbot_backend.model.Project;
+import com.example.clipbot_backend.model.ProjectMediaLink;
+import com.example.clipbot_backend.repository.AccountRepository;
+import com.example.clipbot_backend.repository.AssetRepository;
+import com.example.clipbot_backend.repository.MediaRepository;
+import com.example.clipbot_backend.repository.ProjectMediaRepository;
+import com.example.clipbot_backend.repository.ProjectRepository;
+import com.example.clipbot_backend.service.LocalStorageService;
+import com.example.clipbot_backend.service.Interfaces.StorageService;
+import com.example.clipbot_backend.util.AssetKind;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ThumbnailServiceExtractionTest {
+
+    @Mock
+    private ProjectRepository projectRepository;
+    @Mock
+    private ProjectMediaRepository projectMediaRepository;
+    @Mock
+    private AssetRepository assetRepository;
+    @Mock
+    private MediaRepository mediaRepository;
+    @Mock
+    private AccountRepository accountRepository;
+
+    @TempDir
+    Path tmp;
+
+    private StorageService storageService;
+    private ThumbnailService thumbnailService;
+
+    @BeforeEach
+    void setUp() {
+        storageService = new LocalStorageService(tmp, "raw", "out");
+        thumbnailService = new ThumbnailService(
+                projectRepository,
+                projectMediaRepository,
+                assetRepository,
+                mediaRepository,
+                accountRepository,
+                storageService,
+                "ffmpeg"
+        );
+    }
+
+    @Test
+    void extractsThumbnailWhenLocalVideoExists() throws Exception {
+        UUID mediaId = UUID.randomUUID();
+        UUID ownerId = UUID.randomUUID();
+        Media media = new Media();
+        media.setId(mediaId);
+        media.setDurationMs(12_000L);
+        media.setObjectKey("ext/yt/sample/source.mp4");
+        Account owner = new Account();
+        owner.setId(ownerId);
+        media.setOwner(owner);
+
+        Path rawPath = storageService.resolveRaw(media.getObjectKey());
+        Files.createDirectories(rawPath.getParent());
+
+        Process ffmpeg = new ProcessBuilder(
+                "ffmpeg", "-y",
+                "-f", "lavfi",
+                "-i", "color=c=red:s=160x120:d=2",
+                "-pix_fmt", "yuv420p",
+                rawPath.toString()
+        ).redirectErrorStream(true).start();
+        assumeTrue(ffmpeg.waitFor() == 0, "ffmpeg unavailable");
+
+        Project project = new Project(owner, "demo", null, null);
+        project.setId(UUID.randomUUID());
+        ProjectMediaLink link = new ProjectMediaLink(project, media);
+
+        when(mediaRepository.getReferenceById(mediaId)).thenReturn(media);
+        when(accountRepository.getReferenceById(ownerId)).thenReturn(owner);
+        when(projectMediaRepository.findByMedia(any(Media.class))).thenReturn(List.of(link));
+
+        thumbnailService.extractFromLocalMedia(media, rawPath);
+
+        String expectedThumbKey = String.format("media/thumbs/%s.jpg", mediaId);
+        assertThat(storageService.existsInOut(expectedThumbKey)).isTrue();
+
+        ArgumentCaptor<com.example.clipbot_backend.model.Asset> assetCaptor = ArgumentCaptor.forClass(com.example.clipbot_backend.model.Asset.class);
+        verify(assetRepository).save(assetCaptor.capture());
+        assertThat(assetCaptor.getValue().getKind()).isEqualTo(AssetKind.THUMBNAIL);
+        assertThat(assetCaptor.getValue().getObjectKey()).isEqualTo(expectedThumbKey);
+
+        ArgumentCaptor<List<Project>> projectsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(projectRepository).saveAll(projectsCaptor.capture());
+        assertThat(projectsCaptor.getValue()).hasSize(1);
+        assertThat(projectsCaptor.getValue().get(0).getThumbnailUrl()).isEqualTo(expectedThumbKey);
+    }
+}

--- a/src/test/java/com/example/clipbot_backend/util/HeuristicScorerSpeakerTest.java
+++ b/src/test/java/com/example/clipbot_backend/util/HeuristicScorerSpeakerTest.java
@@ -1,0 +1,53 @@
+package com.example.clipbot_backend.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.clipbot_backend.dto.SentenceSpan;
+import com.example.clipbot_backend.dto.SpeakerTurn;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class HeuristicScorerSpeakerTest {
+
+    private final HeuristicScorer scorer = new HeuristicScorer();
+
+    @Test
+    void speakerAwareScoringRewardsAlignedBoundaries() {
+        List<SentenceSpan> sentences = List.of(
+                new SentenceSpan(0, 2000, "Hello there."),
+                new SentenceSpan(2000, 4000, "Second sentence."),
+                new SentenceSpan(4000, 7000, "Third line with punctuation!")
+        );
+        List<SpeakerTurn> turns = List.of(
+                new SpeakerTurn("A", 0, 4000),
+                new SpeakerTurn("B", 4000, 8000)
+        );
+        HeuristicScorer.SpeakerContext context = new HeuristicScorer.SpeakerContext(turns, true);
+
+        var aligned = scorer.scoreWindow(sentences, 6.0, 3.0, context, 0, 6000);
+        var midTurn = scorer.scoreWindow(sentences, 6.0, 3.0, context, 1000, 6500);
+
+        assertThat(aligned.speakerHeuristicsApplied()).isTrue();
+        assertThat(aligned.overall()).isGreaterThan(midTurn.overall());
+    }
+
+    @Test
+    void speakerHeuristicsDisabledKeepBaseScore() {
+        List<SentenceSpan> sentences = List.of(
+                new SentenceSpan(0, 2000, "Hello there."),
+                new SentenceSpan(2000, 4000, "Second sentence."),
+                new SentenceSpan(4000, 7000, "Third line with punctuation!")
+        );
+        List<SpeakerTurn> turns = List.of(
+                new SpeakerTurn("A", 0, 4000),
+                new SpeakerTurn("B", 4000, 8000)
+        );
+        HeuristicScorer.SpeakerContext disabled = new HeuristicScorer.SpeakerContext(turns, false);
+
+        var baseline = scorer.scoreWindow(sentences, 6.0, 3.0, disabled, 0, 6000);
+        var withoutContext = scorer.scoreWindow(sentences, 6.0, 3.0, null, 0, 6000);
+
+        assertThat(disabled.speakerHeuristicsApplied()).isFalse();
+        assertThat(baseline.overall()).isEqualTo(withoutContext.overall());
+    }
+}


### PR DESCRIPTION
## Summary
- add podcast/interview intent flags to URL ingest and local uploads, persisting explicit speaker mode defaults and updating migration
- route MULTI-speaker media to GPT diarization with fallback to FasterWhisper and log selection, keeping SINGLE on the faster engine
- apply speaker-aware scoring bonuses/penalties using diarization turns and add coverage for ingest, engine selection, and scoring

## Testing
- mvn test *(fails: POM declares self-dependency in current tree)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694000707f548331877d3b37a4b2fccf)